### PR TITLE
Fix dropped attribute string

### DIFF
--- a/src/XmlParser.elm
+++ b/src/XmlParser.elm
@@ -351,7 +351,10 @@ textString end_ =
             |> andThen
                 (\s ->
                     oneOf
-                        [ succeed String.cons
+                        [ succeed
+                            (\c t ->
+                                s ++ String.cons c t
+                            )
                             |= escapedChar end_
                             |= lazy (\_ -> textString end_)
                         , succeed s

--- a/tests/HtmlRendererTests.elm
+++ b/tests/HtmlRendererTests.elm
@@ -218,4 +218,73 @@ Expecting attribute "first".
                                 }
                             ]
                         )
+        , test "html entity in attribute" <|
+            \() ->
+                """<link url="https://example.com?a=1&amp;b=2" />"""
+                    |> render
+                        (testRenderer
+                            [ Markdown.Html.tag "link"
+                                (\urlText children ->
+                                    Html
+                                        { tag = "link"
+                                        , urlText = urlText
+                                        }
+                                )
+                                |> Markdown.Html.withAttribute "url"
+                            ]
+                        )
+                    |> Expect.equal
+                        (Ok
+                            [ Html
+                                { tag = "link"
+                                , urlText = "https://example.com?a=1&b=2"
+                                }
+                            ]
+                        )
+        , test "html code in attribute" <|
+            \() ->
+                """<link url="https://example.com?a=1&#38;b=2" />"""
+                    |> render
+                        (testRenderer
+                            [ Markdown.Html.tag "link"
+                                (\urlText children ->
+                                    Html
+                                        { tag = "link"
+                                        , urlText = urlText
+                                        }
+                                )
+                                |> Markdown.Html.withAttribute "url"
+                            ]
+                        )
+                    |> Expect.equal
+                        (Ok
+                            [ Html
+                                { tag = "link"
+                                , urlText = "https://example.com?a=1&b=2"
+                                }
+                            ]
+                        )
+        , test "hex code in attribute" <|
+            \() ->
+                """<link url="https://example.com?a=1&#x26;b=2" />"""
+                    |> render
+                        (testRenderer
+                            [ Markdown.Html.tag "link"
+                                (\urlText children ->
+                                    Html
+                                        { tag = "link"
+                                        , urlText = urlText
+                                        }
+                                )
+                                |> Markdown.Html.withAttribute "url"
+                            ]
+                        )
+                    |> Expect.equal
+                        (Ok
+                            [ Html
+                                { tag = "link"
+                                , urlText = "https://example.com?a=1&b=2"
+                                }
+                            ]
+                        )
         ]


### PR DESCRIPTION
The `textString` function in `XmlParser.elm` currently drops the first part of an attribute string when it parses an escaped charcater such as `&amp;`. I modified `textString` so that it concatenates the result so far with the escaped character and any string that might follow.

I have also added tests for HTML entities, HTML codes, and hex codes, which are the three varieties of escaped characters handled by `XmlParser.elm`.
