### PR TITLE
Make test result order deterministic

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,14 +2,9 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="0b59cffb-0820-46ca-be64-42696fef5c0d" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/elm-markdown-parser.iml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/elm-markdown-parser.iml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/Markdown/UnorderedList.elm" beforeDir="false" afterPath="$PROJECT_DIR$/src/Markdown/UnorderedList.elm" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test-results/failing/GFM/[extension] Task list items.md" beforeDir="false" afterPath="$PROJECT_DIR$/test-results/failing/GFM/[extension] Task list items.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test-results/failing/ReDOS/link_redos.md" beforeDir="false" afterPath="$PROJECT_DIR$/test-results/failing/ReDOS/link_redos.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test-results/passing-CommonMark.md" beforeDir="false" afterPath="$PROJECT_DIR$/test-results/passing-CommonMark.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test-results/passing-GFM.md" beforeDir="false" afterPath="$PROJECT_DIR$/test-results/passing-GFM.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/UnorderedListTests.elm" beforeDir="false" afterPath="$PROJECT_DIR$/tests/UnorderedListTests.elm" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Markdown/OrderedList.elm" beforeDir="false" afterPath="$PROJECT_DIR$/src/Markdown/OrderedList.elm" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/OrderedListTests.elm" beforeDir="false" afterPath="$PROJECT_DIR$/tests/OrderedListTests.elm" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -96,6 +91,9 @@
       </method>
     </configuration>
   </component>
+  <component name="ServiceViewManager">
+    <option name="showServicesTree" value="false" />
+  </component>
   <component name="SvnConfiguration">
     <configuration />
   </component>
@@ -147,10 +145,10 @@
       <screen x="0" y="0" width="1920" height="1080" />
     </state>
     <state x="565" y="304" width="662" height="472" key="find.popup/0.0.1920.1080/-1050.-138.1050.1680@0.0.1920.1080" timestamp="1581362438203" />
-    <state x="601" y="203" width="718" height="652" key="search.everywhere.popup" timestamp="1581362959924">
+    <state x="601" y="203" width="718" height="652" key="search.everywhere.popup" timestamp="1581363007910">
       <screen x="0" y="0" width="1920" height="1080" />
     </state>
     <state x="561" y="211" width="670" height="676" key="search.everywhere.popup/0.0.1792.1120@0.0.1792.1120" timestamp="1581354562957" />
-    <state x="601" y="203" width="718" height="652" key="search.everywhere.popup/0.0.1920.1080/-1050.-138.1050.1680@0.0.1920.1080" timestamp="1581362959924" />
+    <state x="601" y="203" width="718" height="652" key="search.everywhere.popup/0.0.1920.1080/-1050.-138.1050.1680@0.0.1920.1080" timestamp="1581363007910" />
   </component>
 </project>

--- a/test-results/passing-CommonMark.md
+++ b/test-results/passing-CommonMark.md
@@ -1,14 +1,19 @@
 # CommonMark
 
-## Links
+## ATX headings
 
-### [Example 482](https://spec.commonmark.org/0.29/#example-482)
+### [Example 32](https://spec.commonmark.org/0.29/#example-32)
 
 This markdown:
 
 
 ```markdown
-[link](/uri)
+# foo
+## foo
+### foo
+#### foo
+##### foo
+###### foo
 
 ```
 
@@ -16,17 +21,22 @@ Gives this correct output:
 
 
 ```html
-<p><a href="/uri">link</a></p>
+<h1>foo</h1>
+<h2>foo</h2>
+<h3>foo</h3>
+<h4>foo</h4>
+<h5>foo</h5>
+<h6>foo</h6>
 
 ```
 
-### [Example 483](https://spec.commonmark.org/0.29/#example-483)
+### [Example 37](https://spec.commonmark.org/0.29/#example-37)
 
 This markdown:
 
 
 ```markdown
-[link]()
+#                  foo                     
 
 ```
 
@@ -34,17 +44,17 @@ Gives this correct output:
 
 
 ```html
-<p><a href="">link</a></p>
+<h1>foo</h1>
 
 ```
 
-### [Example 484](https://spec.commonmark.org/0.29/#example-484)
+### [Example 39](https://spec.commonmark.org/0.29/#example-39)
 
 This markdown:
 
 
 ```markdown
-[link](<>)
+    # foo
 
 ```
 
@@ -52,214 +62,19 @@ Gives this correct output:
 
 
 ```html
-<p><a href="">link</a></p>
-
-```
-
-### [Example 489](https://spec.commonmark.org/0.29/#example-489)
-
-This markdown:
-
-
-```markdown
-[a](<b)c>)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="b)c">a</a></p>
-
-```
-
-### [Example 495](https://spec.commonmark.org/0.29/#example-495)
-
-This markdown:
-
-
-```markdown
-[link](<foo(and(bar)>)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="foo(and(bar)">link</a></p>
-
-```
-
-### [Example 497](https://spec.commonmark.org/0.29/#example-497)
-
-This markdown:
-
-
-```markdown
-[link](#fragment)
-
-[link](http://example.com#fragment)
-
-[link](http://example.com?foo=3#frag)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="#fragment">link</a></p>
-<p><a href="http://example.com#fragment">link</a></p>
-<p><a href="http://example.com?foo=3#frag">link</a></p>
-
-```
-
-## Paragraphs
-
-### [Example 189](https://spec.commonmark.org/0.29/#example-189)
-
-This markdown:
-
-
-```markdown
-aaa
-
-bbb
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>aaa</p>
-<p>bbb</p>
-
-```
-
-### [Example 190](https://spec.commonmark.org/0.29/#example-190)
-
-This markdown:
-
-
-```markdown
-aaa
-bbb
-
-ccc
-ddd
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>aaa
-bbb</p>
-<p>ccc
-ddd</p>
-
-```
-
-### [Example 191](https://spec.commonmark.org/0.29/#example-191)
-
-This markdown:
-
-
-```markdown
-aaa
-
-
-bbb
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>aaa</p>
-<p>bbb</p>
-
-```
-
-### [Example 195](https://spec.commonmark.org/0.29/#example-195)
-
-This markdown:
-
-
-```markdown
-    aaa
-bbb
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>aaa
-</code></pre>
-<p>bbb</p>
-
-```
-
-## Indented code blocks
-
-### [Example 84](https://spec.commonmark.org/0.29/#example-84)
-
-This markdown:
-
-
-```markdown
-    foo
-bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>foo
-</code></pre>
-<p>bar</p>
-
-```
-
-### [Example 88](https://spec.commonmark.org/0.29/#example-88)
-
-This markdown:
-
-
-```markdown
-    foo  
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>foo  
+<pre><code># foo
 </code></pre>
 
 ```
 
-## List items
-
-### [Example 231](https://spec.commonmark.org/0.29/#example-231)
+### [Example 42](https://spec.commonmark.org/0.29/#example-42)
 
 This markdown:
 
 
 ```markdown
--one
-
-2.two
+# foo ##################################
+##### foo ##
 
 ```
 
@@ -267,18 +82,18 @@ Gives this correct output:
 
 
 ```html
-<p>-one</p>
-<p>2.two</p>
+<h1>foo</h1>
+<h5>foo</h5>
 
 ```
 
-### [Example 235](https://spec.commonmark.org/0.29/#example-235)
+### [Example 44](https://spec.commonmark.org/0.29/#example-44)
 
 This markdown:
 
 
 ```markdown
-123456789. ok
+### foo ### b
 
 ```
 
@@ -286,19 +101,19 @@ Gives this correct output:
 
 
 ```html
-<ol start="123456789">
-<li>ok</li>
-</ol>
+<h3>foo ### b</h3>
 
 ```
 
-### [Example 236](https://spec.commonmark.org/0.29/#example-236)
+### [Example 47](https://spec.commonmark.org/0.29/#example-47)
 
 This markdown:
 
 
 ```markdown
-1234567890. not ok
+****
+## foo
+****
 
 ```
 
@@ -306,17 +121,21 @@ Gives this correct output:
 
 
 ```html
-<p>1234567890. not ok</p>
+<hr />
+<h2>foo</h2>
+<hr />
 
 ```
 
-### [Example 237](https://spec.commonmark.org/0.29/#example-237)
+### [Example 48](https://spec.commonmark.org/0.29/#example-48)
 
 This markdown:
 
 
 ```markdown
-0. ok
+Foo bar
+# baz
+Bar foo
 
 ```
 
@@ -324,19 +143,21 @@ Gives this correct output:
 
 
 ```html
-<ol start="0">
-<li>ok</li>
-</ol>
+<p>Foo bar</p>
+<h1>baz</h1>
+<p>Bar foo</p>
 
 ```
 
-### [Example 238](https://spec.commonmark.org/0.29/#example-238)
+### [Example 49](https://spec.commonmark.org/0.29/#example-49)
 
 This markdown:
 
 
 ```markdown
-003. ok
+## 
+#
+### ###
 
 ```
 
@@ -344,19 +165,21 @@ Gives this correct output:
 
 
 ```html
-<ol start="3">
-<li>ok</li>
-</ol>
+<h2></h2>
+<h1></h1>
+<h3></h3>
 
 ```
 
-### [Example 239](https://spec.commonmark.org/0.29/#example-239)
+## Autolinks
+
+### [Example 607](https://spec.commonmark.org/0.29/#example-607)
 
 This markdown:
 
 
 ```markdown
--1. not ok
+http://example.com
 
 ```
 
@@ -364,21 +187,17 @@ Gives this correct output:
 
 
 ```html
-<p>-1. not ok</p>
+<p>http://example.com</p>
 
 ```
 
-### [Example 242](https://spec.commonmark.org/0.29/#example-242)
+### [Example 608](https://spec.commonmark.org/0.29/#example-608)
 
 This markdown:
 
 
 ```markdown
-    indented code
-
-paragraph
-
-    more code
+foo@bar.example.com
 
 ```
 
@@ -386,83 +205,67 @@ Gives this correct output:
 
 
 ```html
-<pre><code>indented code
+<p>foo@bar.example.com</p>
+
+```
+
+## Backslash escapes
+
+### [Example 299](https://spec.commonmark.org/0.29/#example-299)
+
+This markdown:
+
+
+```markdown
+\	\A\a\ \3\φ\«
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>\	\A\a\ \3\φ\«</p>
+
+```
+
+### [Example 304](https://spec.commonmark.org/0.29/#example-304)
+
+This markdown:
+
+
+```markdown
+    \[\]
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>\[\]
 </code></pre>
-<p>paragraph</p>
-<pre><code>more code
+
+```
+
+### [Example 305](https://spec.commonmark.org/0.29/#example-305)
+
+This markdown:
+
+
+```markdown
+~~~
+\[\]
+~~~
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>\[\]
 </code></pre>
-
-```
-
-### [Example 251](https://spec.commonmark.org/0.29/#example-251)
-
-This markdown:
-
-
-```markdown
-- foo
--
-- bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<ul>
-<li>foo</li>
-<li></li>
-<li>bar</li>
-</ul>
-
-```
-
-### [Example 252](https://spec.commonmark.org/0.29/#example-252)
-
-This markdown:
-
-
-```markdown
-- foo
--   
-- bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<ul>
-<li>foo</li>
-<li></li>
-<li>bar</li>
-</ul>
-
-```
-
-### [Example 253](https://spec.commonmark.org/0.29/#example-253)
-
-This markdown:
-
-
-```markdown
-1. foo
-2.
-3. bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<ol>
-<li>foo</li>
-<li></li>
-<li>bar</li>
-</ol>
 
 ```
 
@@ -558,100 +361,6 @@ Gives this correct output:
 
 ```html
 <p><code>foo   bar  baz</code></p>
-
-```
-
-## HTML blocks
-
-### [Example 122](https://spec.commonmark.org/0.29/#example-122)
-
-This markdown:
-
-
-```markdown
-<DIV CLASS="foo">
-
-*Markdown*
-
-</DIV>
-
-```
-
-Gives this correct output:
-
-
-```html
-<DIV CLASS="foo">
-<p><em>Markdown</em></p>
-</DIV>
-
-```
-
-### [Example 123](https://spec.commonmark.org/0.29/#example-123)
-
-This markdown:
-
-
-```markdown
-<div id="foo"
-  class="bar">
-</div>
-
-```
-
-Gives this correct output:
-
-
-```html
-<div id="foo"
-  class="bar">
-</div>
-
-```
-
-### [Example 124](https://spec.commonmark.org/0.29/#example-124)
-
-This markdown:
-
-
-```markdown
-<div id="foo" class="bar
-  baz">
-</div>
-
-```
-
-Gives this correct output:
-
-
-```html
-<div id="foo" class="bar
-  baz">
-</div>
-
-```
-
-### [Example 157](https://spec.commonmark.org/0.29/#example-157)
-
-This markdown:
-
-
-```markdown
-<div>
-
-*Emphasized* text.
-
-</div>
-
-```
-
-Gives this correct output:
-
-
-```html
-<div>
-<p><em>Emphasized</em> text.</p>
-</div>
 
 ```
 
@@ -1591,15 +1300,19 @@ Gives this correct output:
 
 ```
 
-## Tabs
+## HTML blocks
 
-### [Example 1](https://spec.commonmark.org/0.29/#example-1)
+### [Example 122](https://spec.commonmark.org/0.29/#example-122)
 
 This markdown:
 
 
 ```markdown
-	foo	baz		bim
+<DIV CLASS="foo">
+
+*Markdown*
+
+</DIV>
 
 ```
 
@@ -1607,18 +1320,21 @@ Gives this correct output:
 
 
 ```html
-<pre><code>foo	baz		bim
-</code></pre>
+<DIV CLASS="foo">
+<p><em>Markdown</em></p>
+</DIV>
 
 ```
 
-### [Example 10](https://spec.commonmark.org/0.29/#example-10)
+### [Example 123](https://spec.commonmark.org/0.29/#example-123)
 
 This markdown:
 
 
 ```markdown
-#	Foo
+<div id="foo"
+  class="bar">
+</div>
 
 ```
 
@@ -1626,19 +1342,21 @@ Gives this correct output:
 
 
 ```html
-<h1>Foo</h1>
+<div id="foo"
+  class="bar">
+</div>
 
 ```
 
-## Textual content
-
-### [Example 647](https://spec.commonmark.org/0.29/#example-647)
+### [Example 124](https://spec.commonmark.org/0.29/#example-124)
 
 This markdown:
 
 
 ```markdown
-hello $.;'there
+<div id="foo" class="bar
+  baz">
+</div>
 
 ```
 
@@ -1646,17 +1364,23 @@ Gives this correct output:
 
 
 ```html
-<p>hello $.;'there</p>
+<div id="foo" class="bar
+  baz">
+</div>
 
 ```
 
-### [Example 648](https://spec.commonmark.org/0.29/#example-648)
+### [Example 157](https://spec.commonmark.org/0.29/#example-157)
 
 This markdown:
 
 
 ```markdown
-Foo χρῆν
+<div>
+
+*Emphasized* text.
+
+</div>
 
 ```
 
@@ -1664,17 +1388,22 @@ Gives this correct output:
 
 
 ```html
-<p>Foo χρῆν</p>
+<div>
+<p><em>Emphasized</em> text.</p>
+</div>
 
 ```
 
-### [Example 649](https://spec.commonmark.org/0.29/#example-649)
+## Hard line breaks
+
+### [Example 637](https://spec.commonmark.org/0.29/#example-637)
 
 This markdown:
 
 
 ```markdown
-Multiple     spaces
+`code 
+span`
 
 ```
 
@@ -1682,24 +1411,18 @@ Gives this correct output:
 
 
 ```html
-<p>Multiple     spaces</p>
+<p><code>code  span</code></p>
 
 ```
 
-## ATX headings
-
-### [Example 32](https://spec.commonmark.org/0.29/#example-32)
+### [Example 638](https://spec.commonmark.org/0.29/#example-638)
 
 This markdown:
 
 
 ```markdown
-# foo
-## foo
-### foo
-#### foo
-##### foo
-###### foo
+`code\
+span`
 
 ```
 
@@ -1707,22 +1430,92 @@ Gives this correct output:
 
 
 ```html
-<h1>foo</h1>
-<h2>foo</h2>
+<p><code>code\ span</code></p>
+
+```
+
+### [Example 641](https://spec.commonmark.org/0.29/#example-641)
+
+This markdown:
+
+
+```markdown
+foo\
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo\</p>
+
+```
+
+### [Example 642](https://spec.commonmark.org/0.29/#example-642)
+
+This markdown:
+
+
+```markdown
+foo  
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo</p>
+
+```
+
+### [Example 643](https://spec.commonmark.org/0.29/#example-643)
+
+This markdown:
+
+
+```markdown
+### foo\
+
+```
+
+Gives this correct output:
+
+
+```html
+<h3>foo\</h3>
+
+```
+
+### [Example 644](https://spec.commonmark.org/0.29/#example-644)
+
+This markdown:
+
+
+```markdown
+### foo  
+
+```
+
+Gives this correct output:
+
+
+```html
 <h3>foo</h3>
-<h4>foo</h4>
-<h5>foo</h5>
-<h6>foo</h6>
 
 ```
 
-### [Example 37](https://spec.commonmark.org/0.29/#example-37)
+## Indented code blocks
+
+### [Example 84](https://spec.commonmark.org/0.29/#example-84)
 
 This markdown:
 
 
 ```markdown
-#                  foo                     
+    foo
+bar
 
 ```
 
@@ -1730,17 +1523,19 @@ Gives this correct output:
 
 
 ```html
-<h1>foo</h1>
+<pre><code>foo
+</code></pre>
+<p>bar</p>
 
 ```
 
-### [Example 39](https://spec.commonmark.org/0.29/#example-39)
+### [Example 88](https://spec.commonmark.org/0.29/#example-88)
 
 This markdown:
 
 
 ```markdown
-    # foo
+    foo  
 
 ```
 
@@ -1748,19 +1543,20 @@ Gives this correct output:
 
 
 ```html
-<pre><code># foo
+<pre><code>foo  
 </code></pre>
 
 ```
 
-### [Example 42](https://spec.commonmark.org/0.29/#example-42)
+## Links
+
+### [Example 482](https://spec.commonmark.org/0.29/#example-482)
 
 This markdown:
 
 
 ```markdown
-# foo ##################################
-##### foo ##
+[link](/uri)
 
 ```
 
@@ -1768,18 +1564,17 @@ Gives this correct output:
 
 
 ```html
-<h1>foo</h1>
-<h5>foo</h5>
+<p><a href="/uri">link</a></p>
 
 ```
 
-### [Example 44](https://spec.commonmark.org/0.29/#example-44)
+### [Example 483](https://spec.commonmark.org/0.29/#example-483)
 
 This markdown:
 
 
 ```markdown
-### foo ### b
+[link]()
 
 ```
 
@@ -1787,19 +1582,17 @@ Gives this correct output:
 
 
 ```html
-<h3>foo ### b</h3>
+<p><a href="">link</a></p>
 
 ```
 
-### [Example 47](https://spec.commonmark.org/0.29/#example-47)
+### [Example 484](https://spec.commonmark.org/0.29/#example-484)
 
 This markdown:
 
 
 ```markdown
-****
-## foo
-****
+[link](<>)
 
 ```
 
@@ -1807,21 +1600,17 @@ Gives this correct output:
 
 
 ```html
-<hr />
-<h2>foo</h2>
-<hr />
+<p><a href="">link</a></p>
 
 ```
 
-### [Example 48](https://spec.commonmark.org/0.29/#example-48)
+### [Example 489](https://spec.commonmark.org/0.29/#example-489)
 
 This markdown:
 
 
 ```markdown
-Foo bar
-# baz
-Bar foo
+[a](<b)c>)
 
 ```
 
@@ -1829,21 +1618,17 @@ Gives this correct output:
 
 
 ```html
-<p>Foo bar</p>
-<h1>baz</h1>
-<p>Bar foo</p>
+<p><a href="b)c">a</a></p>
 
 ```
 
-### [Example 49](https://spec.commonmark.org/0.29/#example-49)
+### [Example 495](https://spec.commonmark.org/0.29/#example-495)
 
 This markdown:
 
 
 ```markdown
-## 
-#
-### ###
+[link](<foo(and(bar)>)
 
 ```
 
@@ -1851,9 +1636,248 @@ Gives this correct output:
 
 
 ```html
-<h2></h2>
-<h1></h1>
-<h3></h3>
+<p><a href="foo(and(bar)">link</a></p>
+
+```
+
+### [Example 497](https://spec.commonmark.org/0.29/#example-497)
+
+This markdown:
+
+
+```markdown
+[link](#fragment)
+
+[link](http://example.com#fragment)
+
+[link](http://example.com?foo=3#frag)
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><a href="#fragment">link</a></p>
+<p><a href="http://example.com#fragment">link</a></p>
+<p><a href="http://example.com?foo=3#frag">link</a></p>
+
+```
+
+## List items
+
+### [Example 231](https://spec.commonmark.org/0.29/#example-231)
+
+This markdown:
+
+
+```markdown
+-one
+
+2.two
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>-one</p>
+<p>2.two</p>
+
+```
+
+### [Example 235](https://spec.commonmark.org/0.29/#example-235)
+
+This markdown:
+
+
+```markdown
+123456789. ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol start="123456789">
+<li>ok</li>
+</ol>
+
+```
+
+### [Example 236](https://spec.commonmark.org/0.29/#example-236)
+
+This markdown:
+
+
+```markdown
+1234567890. not ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>1234567890. not ok</p>
+
+```
+
+### [Example 237](https://spec.commonmark.org/0.29/#example-237)
+
+This markdown:
+
+
+```markdown
+0. ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol start="0">
+<li>ok</li>
+</ol>
+
+```
+
+### [Example 238](https://spec.commonmark.org/0.29/#example-238)
+
+This markdown:
+
+
+```markdown
+003. ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol start="3">
+<li>ok</li>
+</ol>
+
+```
+
+### [Example 239](https://spec.commonmark.org/0.29/#example-239)
+
+This markdown:
+
+
+```markdown
+-1. not ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>-1. not ok</p>
+
+```
+
+### [Example 242](https://spec.commonmark.org/0.29/#example-242)
+
+This markdown:
+
+
+```markdown
+    indented code
+
+paragraph
+
+    more code
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>indented code
+</code></pre>
+<p>paragraph</p>
+<pre><code>more code
+</code></pre>
+
+```
+
+### [Example 251](https://spec.commonmark.org/0.29/#example-251)
+
+This markdown:
+
+
+```markdown
+- foo
+-
+- bar
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ul>
+
+```
+
+### [Example 252](https://spec.commonmark.org/0.29/#example-252)
+
+This markdown:
+
+
+```markdown
+- foo
+-   
+- bar
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ul>
+
+```
+
+### [Example 253](https://spec.commonmark.org/0.29/#example-253)
+
+This markdown:
+
+
+```markdown
+1. foo
+2.
+3. bar
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ol>
 
 ```
 
@@ -1997,15 +2021,17 @@ Gives this correct output:
 
 ```
 
-## Autolinks
+## Paragraphs
 
-### [Example 607](https://spec.commonmark.org/0.29/#example-607)
+### [Example 189](https://spec.commonmark.org/0.29/#example-189)
 
 This markdown:
 
 
 ```markdown
-http://example.com
+aaa
+
+bbb
 
 ```
 
@@ -2013,17 +2039,22 @@ Gives this correct output:
 
 
 ```html
-<p>http://example.com</p>
+<p>aaa</p>
+<p>bbb</p>
 
 ```
 
-### [Example 608](https://spec.commonmark.org/0.29/#example-608)
+### [Example 190](https://spec.commonmark.org/0.29/#example-190)
 
 This markdown:
 
 
 ```markdown
-foo@bar.example.com
+aaa
+bbb
+
+ccc
+ddd
 
 ```
 
@@ -2031,7 +2062,94 @@ Gives this correct output:
 
 
 ```html
-<p>foo@bar.example.com</p>
+<p>aaa
+bbb</p>
+<p>ccc
+ddd</p>
+
+```
+
+### [Example 191](https://spec.commonmark.org/0.29/#example-191)
+
+This markdown:
+
+
+```markdown
+aaa
+
+
+bbb
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>aaa</p>
+<p>bbb</p>
+
+```
+
+### [Example 195](https://spec.commonmark.org/0.29/#example-195)
+
+This markdown:
+
+
+```markdown
+    aaa
+bbb
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>aaa
+</code></pre>
+<p>bbb</p>
+
+```
+
+## Raw HTML
+
+### [Example 622](https://spec.commonmark.org/0.29/#example-622)
+
+This markdown:
+
+
+```markdown
+foo <!-- not a comment -- two hyphens -->
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
+
+```
+
+### [Example 623](https://spec.commonmark.org/0.29/#example-623)
+
+This markdown:
+
+
+```markdown
+foo <!--> foo -->
+
+foo <!-- foo--->
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo &lt;!--&gt; foo --&gt;</p>
+<p>foo &lt;!-- foo---&gt;</p>
 
 ```
 
@@ -2167,118 +2285,6 @@ bar</p>
 
 ```
 
-## Hard line breaks
-
-### [Example 637](https://spec.commonmark.org/0.29/#example-637)
-
-This markdown:
-
-
-```markdown
-`code 
-span`
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><code>code  span</code></p>
-
-```
-
-### [Example 638](https://spec.commonmark.org/0.29/#example-638)
-
-This markdown:
-
-
-```markdown
-`code\
-span`
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><code>code\ span</code></p>
-
-```
-
-### [Example 641](https://spec.commonmark.org/0.29/#example-641)
-
-This markdown:
-
-
-```markdown
-foo\
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>foo\</p>
-
-```
-
-### [Example 642](https://spec.commonmark.org/0.29/#example-642)
-
-This markdown:
-
-
-```markdown
-foo  
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>foo</p>
-
-```
-
-### [Example 643](https://spec.commonmark.org/0.29/#example-643)
-
-This markdown:
-
-
-```markdown
-### foo\
-
-```
-
-Gives this correct output:
-
-
-```html
-<h3>foo\</h3>
-
-```
-
-### [Example 644](https://spec.commonmark.org/0.29/#example-644)
-
-This markdown:
-
-
-```markdown
-### foo  
-
-```
-
-Gives this correct output:
-
-
-```html
-<h3>foo</h3>
-
-```
-
 ## Soft line breaks
 
 ### [Example 645](https://spec.commonmark.org/0.29/#example-645)
@@ -2301,15 +2307,15 @@ baz</p>
 
 ```
 
-## Raw HTML
+## Tabs
 
-### [Example 622](https://spec.commonmark.org/0.29/#example-622)
+### [Example 1](https://spec.commonmark.org/0.29/#example-1)
 
 This markdown:
 
 
 ```markdown
-foo <!-- not a comment -- two hyphens -->
+	foo	baz		bim
 
 ```
 
@@ -2317,79 +2323,18 @@ Gives this correct output:
 
 
 ```html
-<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
-
-```
-
-### [Example 623](https://spec.commonmark.org/0.29/#example-623)
-
-This markdown:
-
-
-```markdown
-foo <!--> foo -->
-
-foo <!-- foo--->
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>foo &lt;!--&gt; foo --&gt;</p>
-<p>foo &lt;!-- foo---&gt;</p>
-
-```
-
-## Backslash escapes
-
-### [Example 299](https://spec.commonmark.org/0.29/#example-299)
-
-This markdown:
-
-
-```markdown
-\	\A\a\ \3\φ\«
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>\	\A\a\ \3\φ\«</p>
-
-```
-
-### [Example 304](https://spec.commonmark.org/0.29/#example-304)
-
-This markdown:
-
-
-```markdown
-    \[\]
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>\[\]
+<pre><code>foo	baz		bim
 </code></pre>
 
 ```
 
-### [Example 305](https://spec.commonmark.org/0.29/#example-305)
+### [Example 10](https://spec.commonmark.org/0.29/#example-10)
 
 This markdown:
 
 
 ```markdown
-~~~
-\[\]
-~~~
+#	Foo
 
 ```
 
@@ -2397,8 +2342,63 @@ Gives this correct output:
 
 
 ```html
-<pre><code>\[\]
-</code></pre>
+<h1>Foo</h1>
+
+```
+
+## Textual content
+
+### [Example 647](https://spec.commonmark.org/0.29/#example-647)
+
+This markdown:
+
+
+```markdown
+hello $.;'there
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>hello $.;'there</p>
+
+```
+
+### [Example 648](https://spec.commonmark.org/0.29/#example-648)
+
+This markdown:
+
+
+```markdown
+Foo χρῆν
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>Foo χρῆν</p>
+
+```
+
+### [Example 649](https://spec.commonmark.org/0.29/#example-649)
+
+This markdown:
+
+
+```markdown
+Multiple     spaces
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>Multiple     spaces</p>
 
 ```
 

--- a/test-results/passing-GFM.md
+++ b/test-results/passing-GFM.md
@@ -1,16 +1,19 @@
 # GFM
 
-## Lists
+## ATX headings
 
-### [Example 271](https://spec.commonmark.org/0.29/#example-271)
+### [Example 32](https://spec.commonmark.org/0.29/#example-32)
 
 This markdown:
 
 
 ```markdown
-- foo
-- bar
-+ baz
+# foo
+## foo
+### foo
+#### foo
+##### foo
+###### foo
 
 ```
 
@@ -18,25 +21,22 @@ Gives this correct output:
 
 
 ```html
-<ul>
-<li>foo</li>
-<li>bar</li>
-</ul>
-<ul>
-<li>baz</li>
-</ul>
+<h1>foo</h1>
+<h2>foo</h2>
+<h3>foo</h3>
+<h4>foo</h4>
+<h5>foo</h5>
+<h6>foo</h6>
 
 ```
 
-### [Example 272](https://spec.commonmark.org/0.29/#example-272)
+### [Example 37](https://spec.commonmark.org/0.29/#example-37)
 
 This markdown:
 
 
 ```markdown
-1. foo
-2. bar
-3) baz
+#                  foo                     
 
 ```
 
@@ -44,25 +44,17 @@ Gives this correct output:
 
 
 ```html
-<ol>
-<li>foo</li>
-<li>bar</li>
-</ol>
-<ol start="3">
-<li>baz</li>
-</ol>
+<h1>foo</h1>
 
 ```
 
-### [Example 273](https://spec.commonmark.org/0.29/#example-273)
+### [Example 39](https://spec.commonmark.org/0.29/#example-39)
 
 This markdown:
 
 
 ```markdown
-Foo
-- bar
-- baz
+    # foo
 
 ```
 
@@ -70,22 +62,19 @@ Gives this correct output:
 
 
 ```html
-<p>Foo</p>
-<ul>
-<li>bar</li>
-<li>baz</li>
-</ul>
+<pre><code># foo
+</code></pre>
 
 ```
 
-### [Example 274](https://spec.commonmark.org/0.29/#example-274)
+### [Example 42](https://spec.commonmark.org/0.29/#example-42)
 
 This markdown:
 
 
 ```markdown
-The number of windows in my house is
-14.  The number of doors is 6.
+# foo ##################################
+##### foo ##
 
 ```
 
@@ -93,19 +82,18 @@ Gives this correct output:
 
 
 ```html
-<p>The number of windows in my house is
-14.  The number of doors is 6.</p>
+<h1>foo</h1>
+<h5>foo</h5>
 
 ```
 
-### [Example 275](https://spec.commonmark.org/0.29/#example-275)
+### [Example 44](https://spec.commonmark.org/0.29/#example-44)
 
 This markdown:
 
 
 ```markdown
-The number of windows in my house is
-1.  The number of doors is 6.
+### foo ### b
 
 ```
 
@@ -113,20 +101,19 @@ Gives this correct output:
 
 
 ```html
-<p>The number of windows in my house is</p>
-<ol>
-<li>The number of doors is 6.</li>
-</ol>
+<h3>foo ### b</h3>
 
 ```
 
-### [Example 292](https://spec.commonmark.org/0.29/#example-292)
+### [Example 47](https://spec.commonmark.org/0.29/#example-47)
 
 This markdown:
 
 
 ```markdown
-- a
+****
+## foo
+****
 
 ```
 
@@ -134,9 +121,91 @@ Gives this correct output:
 
 
 ```html
-<ul>
-<li>a</li>
-</ul>
+<hr />
+<h2>foo</h2>
+<hr />
+
+```
+
+### [Example 48](https://spec.commonmark.org/0.29/#example-48)
+
+This markdown:
+
+
+```markdown
+Foo bar
+# baz
+Bar foo
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>Foo bar</p>
+<h1>baz</h1>
+<p>Bar foo</p>
+
+```
+
+### [Example 49](https://spec.commonmark.org/0.29/#example-49)
+
+This markdown:
+
+
+```markdown
+## 
+#
+### ###
+
+```
+
+Gives this correct output:
+
+
+```html
+<h2></h2>
+<h1></h1>
+<h3></h3>
+
+```
+
+## Autolinks
+
+### [Example 607](https://spec.commonmark.org/0.29/#example-607)
+
+This markdown:
+
+
+```markdown
+http://example.com
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>http://example.com</p>
+
+```
+
+### [Example 608](https://spec.commonmark.org/0.29/#example-608)
+
+This markdown:
+
+
+```markdown
+foo@bar.example.com
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo@bar.example.com</p>
 
 ```
 
@@ -197,100 +266,6 @@ Gives this correct output:
 ```html
 <pre><code>\[\]
 </code></pre>
-
-```
-
-## HTML blocks
-
-### [Example 122](https://spec.commonmark.org/0.29/#example-122)
-
-This markdown:
-
-
-```markdown
-<DIV CLASS="foo">
-
-*Markdown*
-
-</DIV>
-
-```
-
-Gives this correct output:
-
-
-```html
-<DIV CLASS="foo">
-<p><em>Markdown</em></p>
-</DIV>
-
-```
-
-### [Example 123](https://spec.commonmark.org/0.29/#example-123)
-
-This markdown:
-
-
-```markdown
-<div id="foo"
-  class="bar">
-</div>
-
-```
-
-Gives this correct output:
-
-
-```html
-<div id="foo"
-  class="bar">
-</div>
-
-```
-
-### [Example 124](https://spec.commonmark.org/0.29/#example-124)
-
-This markdown:
-
-
-```markdown
-<div id="foo" class="bar
-  baz">
-</div>
-
-```
-
-Gives this correct output:
-
-
-```html
-<div id="foo" class="bar
-  baz">
-</div>
-
-```
-
-### [Example 157](https://spec.commonmark.org/0.29/#example-157)
-
-This markdown:
-
-
-```markdown
-<div>
-
-*Emphasized* text.
-
-</div>
-
-```
-
-Gives this correct output:
-
-
-```html
-<div>
-<p><em>Emphasized</em> text.</p>
-</div>
 
 ```
 
@@ -386,343 +361,6 @@ Gives this correct output:
 
 ```html
 <p><code>foo   bar  baz</code></p>
-
-```
-
-## List items
-
-### [Example 231](https://spec.commonmark.org/0.29/#example-231)
-
-This markdown:
-
-
-```markdown
--one
-
-2.two
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>-one</p>
-<p>2.two</p>
-
-```
-
-### [Example 235](https://spec.commonmark.org/0.29/#example-235)
-
-This markdown:
-
-
-```markdown
-123456789. ok
-
-```
-
-Gives this correct output:
-
-
-```html
-<ol start="123456789">
-<li>ok</li>
-</ol>
-
-```
-
-### [Example 236](https://spec.commonmark.org/0.29/#example-236)
-
-This markdown:
-
-
-```markdown
-1234567890. not ok
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>1234567890. not ok</p>
-
-```
-
-### [Example 237](https://spec.commonmark.org/0.29/#example-237)
-
-This markdown:
-
-
-```markdown
-0. ok
-
-```
-
-Gives this correct output:
-
-
-```html
-<ol start="0">
-<li>ok</li>
-</ol>
-
-```
-
-### [Example 238](https://spec.commonmark.org/0.29/#example-238)
-
-This markdown:
-
-
-```markdown
-003. ok
-
-```
-
-Gives this correct output:
-
-
-```html
-<ol start="3">
-<li>ok</li>
-</ol>
-
-```
-
-### [Example 239](https://spec.commonmark.org/0.29/#example-239)
-
-This markdown:
-
-
-```markdown
--1. not ok
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>-1. not ok</p>
-
-```
-
-### [Example 242](https://spec.commonmark.org/0.29/#example-242)
-
-This markdown:
-
-
-```markdown
-    indented code
-
-paragraph
-
-    more code
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>indented code
-</code></pre>
-<p>paragraph</p>
-<pre><code>more code
-</code></pre>
-
-```
-
-### [Example 251](https://spec.commonmark.org/0.29/#example-251)
-
-This markdown:
-
-
-```markdown
-- foo
--
-- bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<ul>
-<li>foo</li>
-<li></li>
-<li>bar</li>
-</ul>
-
-```
-
-### [Example 252](https://spec.commonmark.org/0.29/#example-252)
-
-This markdown:
-
-
-```markdown
-- foo
--   
-- bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<ul>
-<li>foo</li>
-<li></li>
-<li>bar</li>
-</ul>
-
-```
-
-### [Example 253](https://spec.commonmark.org/0.29/#example-253)
-
-This markdown:
-
-
-```markdown
-1. foo
-2.
-3. bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<ol>
-<li>foo</li>
-<li></li>
-<li>bar</li>
-</ol>
-
-```
-
-## [extension] Strikethrough
-
-### [Example 492](https://github.github.com/gfm/#example-492)
-
-This markdown:
-
-
-```markdown
-This ~~has a
-
-new paragraph~~.
-```
-
-Gives this correct output:
-
-
-```html
-<p>This ~~has a</p>
-<p>new paragraph~~.</p>
-```
-
-## Entity and numeric character references
-
-### [Example 314](https://spec.commonmark.org/0.29/#example-314)
-
-This markdown:
-
-
-```markdown
-&nbsp &x; &#; &#x;
-&#987654321;
-&#abcdef0;
-&ThisIsNotDefined; &hi?;
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;
-&amp;#987654321;
-&amp;#abcdef0;
-&amp;ThisIsNotDefined; &amp;hi?;</p>
-
-```
-
-### [Example 315](https://spec.commonmark.org/0.29/#example-315)
-
-This markdown:
-
-
-```markdown
-&copy
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>&amp;copy</p>
-
-```
-
-### [Example 316](https://spec.commonmark.org/0.29/#example-316)
-
-This markdown:
-
-
-```markdown
-&MadeUpEntity;
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>&amp;MadeUpEntity;</p>
-
-```
-
-### [Example 321](https://spec.commonmark.org/0.29/#example-321)
-
-This markdown:
-
-
-```markdown
-`f&ouml;&ouml;`
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><code>f&amp;ouml;&amp;ouml;</code></p>
-
-```
-
-### [Example 322](https://spec.commonmark.org/0.29/#example-322)
-
-This markdown:
-
-
-```markdown
-    f&ouml;f&ouml;
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>f&amp;ouml;f&amp;ouml;
-</code></pre>
 
 ```
 
@@ -1400,15 +1038,18 @@ Gives this correct output:
 
 ```
 
-## Autolinks
+## Entity and numeric character references
 
-### [Example 607](https://spec.commonmark.org/0.29/#example-607)
+### [Example 314](https://spec.commonmark.org/0.29/#example-314)
 
 This markdown:
 
 
 ```markdown
-http://example.com
+&nbsp &x; &#; &#x;
+&#987654321;
+&#abcdef0;
+&ThisIsNotDefined; &hi?;
 
 ```
 
@@ -1416,17 +1057,20 @@ Gives this correct output:
 
 
 ```html
-<p>http://example.com</p>
+<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;
+&amp;#987654321;
+&amp;#abcdef0;
+&amp;ThisIsNotDefined; &amp;hi?;</p>
 
 ```
 
-### [Example 608](https://spec.commonmark.org/0.29/#example-608)
+### [Example 315](https://spec.commonmark.org/0.29/#example-315)
 
 This markdown:
 
 
 ```markdown
-foo@bar.example.com
+&copy
 
 ```
 
@@ -1434,7 +1078,319 @@ Gives this correct output:
 
 
 ```html
-<p>foo@bar.example.com</p>
+<p>&amp;copy</p>
+
+```
+
+### [Example 316](https://spec.commonmark.org/0.29/#example-316)
+
+This markdown:
+
+
+```markdown
+&MadeUpEntity;
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>&amp;MadeUpEntity;</p>
+
+```
+
+### [Example 321](https://spec.commonmark.org/0.29/#example-321)
+
+This markdown:
+
+
+```markdown
+`f&ouml;&ouml;`
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><code>f&amp;ouml;&amp;ouml;</code></p>
+
+```
+
+### [Example 322](https://spec.commonmark.org/0.29/#example-322)
+
+This markdown:
+
+
+```markdown
+    f&ouml;f&ouml;
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>f&amp;ouml;f&amp;ouml;
+</code></pre>
+
+```
+
+## Fenced code blocks
+
+### [Example 89](https://spec.commonmark.org/0.29/#example-89)
+
+This markdown:
+
+
+```markdown
+```
+<
+ >
+```
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>&lt;
+ &gt;
+</code></pre>
+
+```
+
+### [Example 90](https://spec.commonmark.org/0.29/#example-90)
+
+This markdown:
+
+
+```markdown
+~~~
+<
+ >
+~~~
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>&lt;
+ &gt;
+</code></pre>
+
+```
+
+### [Example 92](https://spec.commonmark.org/0.29/#example-92)
+
+This markdown:
+
+
+```markdown
+```
+aaa
+~~~
+```
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>aaa
+~~~
+</code></pre>
+
+```
+
+### [Example 93](https://spec.commonmark.org/0.29/#example-93)
+
+This markdown:
+
+
+```markdown
+~~~
+aaa
+```
+~~~
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>aaa
+```
+</code></pre>
+
+```
+
+### [Example 99](https://spec.commonmark.org/0.29/#example-99)
+
+This markdown:
+
+
+```markdown
+```
+
+  
+```
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>
+  
+</code></pre>
+
+```
+
+### [Example 110](https://spec.commonmark.org/0.29/#example-110)
+
+This markdown:
+
+
+```markdown
+foo
+```
+bar
+```
+baz
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo</p>
+<pre><code>bar
+</code></pre>
+<p>baz</p>
+
+```
+
+### [Example 117](https://spec.commonmark.org/0.29/#example-117)
+
+This markdown:
+
+
+```markdown
+```
+``` aaa
+```
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>``` aaa
+</code></pre>
+
+```
+
+## HTML blocks
+
+### [Example 122](https://spec.commonmark.org/0.29/#example-122)
+
+This markdown:
+
+
+```markdown
+<DIV CLASS="foo">
+
+*Markdown*
+
+</DIV>
+
+```
+
+Gives this correct output:
+
+
+```html
+<DIV CLASS="foo">
+<p><em>Markdown</em></p>
+</DIV>
+
+```
+
+### [Example 123](https://spec.commonmark.org/0.29/#example-123)
+
+This markdown:
+
+
+```markdown
+<div id="foo"
+  class="bar">
+</div>
+
+```
+
+Gives this correct output:
+
+
+```html
+<div id="foo"
+  class="bar">
+</div>
+
+```
+
+### [Example 124](https://spec.commonmark.org/0.29/#example-124)
+
+This markdown:
+
+
+```markdown
+<div id="foo" class="bar
+  baz">
+</div>
+
+```
+
+Gives this correct output:
+
+
+```html
+<div id="foo" class="bar
+  baz">
+</div>
+
+```
+
+### [Example 157](https://spec.commonmark.org/0.29/#example-157)
+
+This markdown:
+
+
+```markdown
+<div>
+
+*Emphasized* text.
+
+</div>
+
+```
+
+Gives this correct output:
+
+
+```html
+<div>
+<p><em>Emphasized</em> text.</p>
+</div>
 
 ```
 
@@ -1547,6 +1503,902 @@ Gives this correct output:
 
 ```html
 <h3>foo</h3>
+
+```
+
+## Indented code blocks
+
+### [Example 84](https://spec.commonmark.org/0.29/#example-84)
+
+This markdown:
+
+
+```markdown
+    foo
+bar
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>foo
+</code></pre>
+<p>bar</p>
+
+```
+
+### [Example 88](https://spec.commonmark.org/0.29/#example-88)
+
+This markdown:
+
+
+```markdown
+    foo  
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>foo  
+</code></pre>
+
+```
+
+## Links
+
+### [Example 482](https://spec.commonmark.org/0.29/#example-482)
+
+This markdown:
+
+
+```markdown
+[link](/uri)
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><a href="/uri">link</a></p>
+
+```
+
+### [Example 483](https://spec.commonmark.org/0.29/#example-483)
+
+This markdown:
+
+
+```markdown
+[link]()
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><a href="">link</a></p>
+
+```
+
+### [Example 484](https://spec.commonmark.org/0.29/#example-484)
+
+This markdown:
+
+
+```markdown
+[link](<>)
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><a href="">link</a></p>
+
+```
+
+### [Example 489](https://spec.commonmark.org/0.29/#example-489)
+
+This markdown:
+
+
+```markdown
+[a](<b)c>)
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><a href="b)c">a</a></p>
+
+```
+
+### [Example 495](https://spec.commonmark.org/0.29/#example-495)
+
+This markdown:
+
+
+```markdown
+[link](<foo(and(bar)>)
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><a href="foo(and(bar)">link</a></p>
+
+```
+
+### [Example 497](https://spec.commonmark.org/0.29/#example-497)
+
+This markdown:
+
+
+```markdown
+[link](#fragment)
+
+[link](http://example.com#fragment)
+
+[link](http://example.com?foo=3#frag)
+
+```
+
+Gives this correct output:
+
+
+```html
+<p><a href="#fragment">link</a></p>
+<p><a href="http://example.com#fragment">link</a></p>
+<p><a href="http://example.com?foo=3#frag">link</a></p>
+
+```
+
+## List items
+
+### [Example 231](https://spec.commonmark.org/0.29/#example-231)
+
+This markdown:
+
+
+```markdown
+-one
+
+2.two
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>-one</p>
+<p>2.two</p>
+
+```
+
+### [Example 235](https://spec.commonmark.org/0.29/#example-235)
+
+This markdown:
+
+
+```markdown
+123456789. ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol start="123456789">
+<li>ok</li>
+</ol>
+
+```
+
+### [Example 236](https://spec.commonmark.org/0.29/#example-236)
+
+This markdown:
+
+
+```markdown
+1234567890. not ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>1234567890. not ok</p>
+
+```
+
+### [Example 237](https://spec.commonmark.org/0.29/#example-237)
+
+This markdown:
+
+
+```markdown
+0. ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol start="0">
+<li>ok</li>
+</ol>
+
+```
+
+### [Example 238](https://spec.commonmark.org/0.29/#example-238)
+
+This markdown:
+
+
+```markdown
+003. ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol start="3">
+<li>ok</li>
+</ol>
+
+```
+
+### [Example 239](https://spec.commonmark.org/0.29/#example-239)
+
+This markdown:
+
+
+```markdown
+-1. not ok
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>-1. not ok</p>
+
+```
+
+### [Example 242](https://spec.commonmark.org/0.29/#example-242)
+
+This markdown:
+
+
+```markdown
+    indented code
+
+paragraph
+
+    more code
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>indented code
+</code></pre>
+<p>paragraph</p>
+<pre><code>more code
+</code></pre>
+
+```
+
+### [Example 251](https://spec.commonmark.org/0.29/#example-251)
+
+This markdown:
+
+
+```markdown
+- foo
+-
+- bar
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ul>
+
+```
+
+### [Example 252](https://spec.commonmark.org/0.29/#example-252)
+
+This markdown:
+
+
+```markdown
+- foo
+-   
+- bar
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ul>
+
+```
+
+### [Example 253](https://spec.commonmark.org/0.29/#example-253)
+
+This markdown:
+
+
+```markdown
+1. foo
+2.
+3. bar
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ol>
+
+```
+
+## Lists
+
+### [Example 271](https://spec.commonmark.org/0.29/#example-271)
+
+This markdown:
+
+
+```markdown
+- foo
+- bar
++ baz
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>foo</li>
+<li>bar</li>
+</ul>
+<ul>
+<li>baz</li>
+</ul>
+
+```
+
+### [Example 272](https://spec.commonmark.org/0.29/#example-272)
+
+This markdown:
+
+
+```markdown
+1. foo
+2. bar
+3) baz
+
+```
+
+Gives this correct output:
+
+
+```html
+<ol>
+<li>foo</li>
+<li>bar</li>
+</ol>
+<ol start="3">
+<li>baz</li>
+</ol>
+
+```
+
+### [Example 273](https://spec.commonmark.org/0.29/#example-273)
+
+This markdown:
+
+
+```markdown
+Foo
+- bar
+- baz
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>Foo</p>
+<ul>
+<li>bar</li>
+<li>baz</li>
+</ul>
+
+```
+
+### [Example 274](https://spec.commonmark.org/0.29/#example-274)
+
+This markdown:
+
+
+```markdown
+The number of windows in my house is
+14.  The number of doors is 6.
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>The number of windows in my house is
+14.  The number of doors is 6.</p>
+
+```
+
+### [Example 275](https://spec.commonmark.org/0.29/#example-275)
+
+This markdown:
+
+
+```markdown
+The number of windows in my house is
+1.  The number of doors is 6.
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>The number of windows in my house is</p>
+<ol>
+<li>The number of doors is 6.</li>
+</ol>
+
+```
+
+### [Example 292](https://spec.commonmark.org/0.29/#example-292)
+
+This markdown:
+
+
+```markdown
+- a
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>a</li>
+</ul>
+
+```
+
+## Paragraphs
+
+### [Example 189](https://spec.commonmark.org/0.29/#example-189)
+
+This markdown:
+
+
+```markdown
+aaa
+
+bbb
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>aaa</p>
+<p>bbb</p>
+
+```
+
+### [Example 190](https://spec.commonmark.org/0.29/#example-190)
+
+This markdown:
+
+
+```markdown
+aaa
+bbb
+
+ccc
+ddd
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>aaa
+bbb</p>
+<p>ccc
+ddd</p>
+
+```
+
+### [Example 191](https://spec.commonmark.org/0.29/#example-191)
+
+This markdown:
+
+
+```markdown
+aaa
+
+
+bbb
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>aaa</p>
+<p>bbb</p>
+
+```
+
+### [Example 195](https://spec.commonmark.org/0.29/#example-195)
+
+This markdown:
+
+
+```markdown
+    aaa
+bbb
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>aaa
+</code></pre>
+<p>bbb</p>
+
+```
+
+## Raw HTML
+
+### [Example 622](https://spec.commonmark.org/0.29/#example-622)
+
+This markdown:
+
+
+```markdown
+foo <!-- not a comment -- two hyphens -->
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
+
+```
+
+### [Example 623](https://spec.commonmark.org/0.29/#example-623)
+
+This markdown:
+
+
+```markdown
+foo <!--> foo -->
+
+foo <!-- foo--->
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo &lt;!--&gt; foo --&gt;</p>
+<p>foo &lt;!-- foo---&gt;</p>
+
+```
+
+## Setext headings
+
+### [Example 64](https://spec.commonmark.org/0.29/#example-64)
+
+This markdown:
+
+
+```markdown
+- Foo
+---
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>Foo</li>
+</ul>
+<hr />
+
+```
+
+### [Example 67](https://spec.commonmark.org/0.29/#example-67)
+
+This markdown:
+
+
+```markdown
+
+====
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>====</p>
+
+```
+
+### [Example 68](https://spec.commonmark.org/0.29/#example-68)
+
+This markdown:
+
+
+```markdown
+---
+---
+
+```
+
+Gives this correct output:
+
+
+```html
+<hr />
+<hr />
+
+```
+
+### [Example 69](https://spec.commonmark.org/0.29/#example-69)
+
+This markdown:
+
+
+```markdown
+- foo
+-----
+
+```
+
+Gives this correct output:
+
+
+```html
+<ul>
+<li>foo</li>
+</ul>
+<hr />
+
+```
+
+### [Example 70](https://spec.commonmark.org/0.29/#example-70)
+
+This markdown:
+
+
+```markdown
+    foo
+---
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>foo
+</code></pre>
+<hr />
+
+```
+
+### [Example 74](https://spec.commonmark.org/0.29/#example-74)
+
+This markdown:
+
+
+```markdown
+Foo
+bar
+
+---
+
+baz
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>Foo
+bar</p>
+<hr />
+<p>baz</p>
+
+```
+
+## Soft line breaks
+
+### [Example 645](https://spec.commonmark.org/0.29/#example-645)
+
+This markdown:
+
+
+```markdown
+foo
+baz
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>foo
+baz</p>
+
+```
+
+## Tabs
+
+### [Example 1](https://spec.commonmark.org/0.29/#example-1)
+
+This markdown:
+
+
+```markdown
+	foo	baz		bim
+
+```
+
+Gives this correct output:
+
+
+```html
+<pre><code>foo	baz		bim
+</code></pre>
+
+```
+
+### [Example 10](https://spec.commonmark.org/0.29/#example-10)
+
+This markdown:
+
+
+```markdown
+#	Foo
+
+```
+
+Gives this correct output:
+
+
+```html
+<h1>Foo</h1>
+
+```
+
+## Textual content
+
+### [Example 647](https://spec.commonmark.org/0.29/#example-647)
+
+This markdown:
+
+
+```markdown
+hello $.;'there
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>hello $.;'there</p>
+
+```
+
+### [Example 648](https://spec.commonmark.org/0.29/#example-648)
+
+This markdown:
+
+
+```markdown
+Foo χρῆν
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>Foo χρῆν</p>
+
+```
+
+### [Example 649](https://spec.commonmark.org/0.29/#example-649)
+
+This markdown:
+
+
+```markdown
+Multiple     spaces
+
+```
+
+Gives this correct output:
+
+
+```html
+<p>Multiple     spaces</p>
 
 ```
 
@@ -1717,6 +2569,27 @@ Gives this correct output:
 
 ```
 
+## [extension] Strikethrough
+
+### [Example 492](https://github.github.com/gfm/#example-492)
+
+This markdown:
+
+
+```markdown
+This ~~has a
+
+new paragraph~~.
+```
+
+Gives this correct output:
+
+
+```html
+<p>This ~~has a</p>
+<p>new paragraph~~.</p>
+```
+
 ## [extension] Tables
 
 ### [Example 203](https://github.github.com/gfm/#example-203)
@@ -1737,878 +2610,5 @@ Gives this correct output:
 <p>| abc | def |
 | --- |
 | bar |</p>
-```
-
-## Links
-
-### [Example 482](https://spec.commonmark.org/0.29/#example-482)
-
-This markdown:
-
-
-```markdown
-[link](/uri)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="/uri">link</a></p>
-
-```
-
-### [Example 483](https://spec.commonmark.org/0.29/#example-483)
-
-This markdown:
-
-
-```markdown
-[link]()
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="">link</a></p>
-
-```
-
-### [Example 484](https://spec.commonmark.org/0.29/#example-484)
-
-This markdown:
-
-
-```markdown
-[link](<>)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="">link</a></p>
-
-```
-
-### [Example 489](https://spec.commonmark.org/0.29/#example-489)
-
-This markdown:
-
-
-```markdown
-[a](<b)c>)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="b)c">a</a></p>
-
-```
-
-### [Example 495](https://spec.commonmark.org/0.29/#example-495)
-
-This markdown:
-
-
-```markdown
-[link](<foo(and(bar)>)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="foo(and(bar)">link</a></p>
-
-```
-
-### [Example 497](https://spec.commonmark.org/0.29/#example-497)
-
-This markdown:
-
-
-```markdown
-[link](#fragment)
-
-[link](http://example.com#fragment)
-
-[link](http://example.com?foo=3#frag)
-
-```
-
-Gives this correct output:
-
-
-```html
-<p><a href="#fragment">link</a></p>
-<p><a href="http://example.com#fragment">link</a></p>
-<p><a href="http://example.com?foo=3#frag">link</a></p>
-
-```
-
-## Tabs
-
-### [Example 1](https://spec.commonmark.org/0.29/#example-1)
-
-This markdown:
-
-
-```markdown
-	foo	baz		bim
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>foo	baz		bim
-</code></pre>
-
-```
-
-### [Example 10](https://spec.commonmark.org/0.29/#example-10)
-
-This markdown:
-
-
-```markdown
-#	Foo
-
-```
-
-Gives this correct output:
-
-
-```html
-<h1>Foo</h1>
-
-```
-
-## Raw HTML
-
-### [Example 622](https://spec.commonmark.org/0.29/#example-622)
-
-This markdown:
-
-
-```markdown
-foo <!-- not a comment -- two hyphens -->
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
-
-```
-
-### [Example 623](https://spec.commonmark.org/0.29/#example-623)
-
-This markdown:
-
-
-```markdown
-foo <!--> foo -->
-
-foo <!-- foo--->
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>foo &lt;!--&gt; foo --&gt;</p>
-<p>foo &lt;!-- foo---&gt;</p>
-
-```
-
-## Soft line breaks
-
-### [Example 645](https://spec.commonmark.org/0.29/#example-645)
-
-This markdown:
-
-
-```markdown
-foo
-baz
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>foo
-baz</p>
-
-```
-
-## Paragraphs
-
-### [Example 189](https://spec.commonmark.org/0.29/#example-189)
-
-This markdown:
-
-
-```markdown
-aaa
-
-bbb
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>aaa</p>
-<p>bbb</p>
-
-```
-
-### [Example 190](https://spec.commonmark.org/0.29/#example-190)
-
-This markdown:
-
-
-```markdown
-aaa
-bbb
-
-ccc
-ddd
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>aaa
-bbb</p>
-<p>ccc
-ddd</p>
-
-```
-
-### [Example 191](https://spec.commonmark.org/0.29/#example-191)
-
-This markdown:
-
-
-```markdown
-aaa
-
-
-bbb
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>aaa</p>
-<p>bbb</p>
-
-```
-
-### [Example 195](https://spec.commonmark.org/0.29/#example-195)
-
-This markdown:
-
-
-```markdown
-    aaa
-bbb
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>aaa
-</code></pre>
-<p>bbb</p>
-
-```
-
-## Fenced code blocks
-
-### [Example 89](https://spec.commonmark.org/0.29/#example-89)
-
-This markdown:
-
-
-```markdown
-```
-<
- >
-```
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>&lt;
- &gt;
-</code></pre>
-
-```
-
-### [Example 90](https://spec.commonmark.org/0.29/#example-90)
-
-This markdown:
-
-
-```markdown
-~~~
-<
- >
-~~~
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>&lt;
- &gt;
-</code></pre>
-
-```
-
-### [Example 92](https://spec.commonmark.org/0.29/#example-92)
-
-This markdown:
-
-
-```markdown
-```
-aaa
-~~~
-```
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>aaa
-~~~
-</code></pre>
-
-```
-
-### [Example 93](https://spec.commonmark.org/0.29/#example-93)
-
-This markdown:
-
-
-```markdown
-~~~
-aaa
-```
-~~~
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>aaa
-```
-</code></pre>
-
-```
-
-### [Example 99](https://spec.commonmark.org/0.29/#example-99)
-
-This markdown:
-
-
-```markdown
-```
-
-  
-```
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>
-  
-</code></pre>
-
-```
-
-### [Example 110](https://spec.commonmark.org/0.29/#example-110)
-
-This markdown:
-
-
-```markdown
-foo
-```
-bar
-```
-baz
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>foo</p>
-<pre><code>bar
-</code></pre>
-<p>baz</p>
-
-```
-
-### [Example 117](https://spec.commonmark.org/0.29/#example-117)
-
-This markdown:
-
-
-```markdown
-```
-``` aaa
-```
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>``` aaa
-</code></pre>
-
-```
-
-## Textual content
-
-### [Example 647](https://spec.commonmark.org/0.29/#example-647)
-
-This markdown:
-
-
-```markdown
-hello $.;'there
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>hello $.;'there</p>
-
-```
-
-### [Example 648](https://spec.commonmark.org/0.29/#example-648)
-
-This markdown:
-
-
-```markdown
-Foo χρῆν
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>Foo χρῆν</p>
-
-```
-
-### [Example 649](https://spec.commonmark.org/0.29/#example-649)
-
-This markdown:
-
-
-```markdown
-Multiple     spaces
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>Multiple     spaces</p>
-
-```
-
-## Indented code blocks
-
-### [Example 84](https://spec.commonmark.org/0.29/#example-84)
-
-This markdown:
-
-
-```markdown
-    foo
-bar
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>foo
-</code></pre>
-<p>bar</p>
-
-```
-
-### [Example 88](https://spec.commonmark.org/0.29/#example-88)
-
-This markdown:
-
-
-```markdown
-    foo  
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>foo  
-</code></pre>
-
-```
-
-## Setext headings
-
-### [Example 64](https://spec.commonmark.org/0.29/#example-64)
-
-This markdown:
-
-
-```markdown
-- Foo
----
-
-```
-
-Gives this correct output:
-
-
-```html
-<ul>
-<li>Foo</li>
-</ul>
-<hr />
-
-```
-
-### [Example 67](https://spec.commonmark.org/0.29/#example-67)
-
-This markdown:
-
-
-```markdown
-
-====
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>====</p>
-
-```
-
-### [Example 68](https://spec.commonmark.org/0.29/#example-68)
-
-This markdown:
-
-
-```markdown
----
----
-
-```
-
-Gives this correct output:
-
-
-```html
-<hr />
-<hr />
-
-```
-
-### [Example 69](https://spec.commonmark.org/0.29/#example-69)
-
-This markdown:
-
-
-```markdown
-- foo
------
-
-```
-
-Gives this correct output:
-
-
-```html
-<ul>
-<li>foo</li>
-</ul>
-<hr />
-
-```
-
-### [Example 70](https://spec.commonmark.org/0.29/#example-70)
-
-This markdown:
-
-
-```markdown
-    foo
----
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code>foo
-</code></pre>
-<hr />
-
-```
-
-### [Example 74](https://spec.commonmark.org/0.29/#example-74)
-
-This markdown:
-
-
-```markdown
-Foo
-bar
-
----
-
-baz
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>Foo
-bar</p>
-<hr />
-<p>baz</p>
-
-```
-
-## ATX headings
-
-### [Example 32](https://spec.commonmark.org/0.29/#example-32)
-
-This markdown:
-
-
-```markdown
-# foo
-## foo
-### foo
-#### foo
-##### foo
-###### foo
-
-```
-
-Gives this correct output:
-
-
-```html
-<h1>foo</h1>
-<h2>foo</h2>
-<h3>foo</h3>
-<h4>foo</h4>
-<h5>foo</h5>
-<h6>foo</h6>
-
-```
-
-### [Example 37](https://spec.commonmark.org/0.29/#example-37)
-
-This markdown:
-
-
-```markdown
-#                  foo                     
-
-```
-
-Gives this correct output:
-
-
-```html
-<h1>foo</h1>
-
-```
-
-### [Example 39](https://spec.commonmark.org/0.29/#example-39)
-
-This markdown:
-
-
-```markdown
-    # foo
-
-```
-
-Gives this correct output:
-
-
-```html
-<pre><code># foo
-</code></pre>
-
-```
-
-### [Example 42](https://spec.commonmark.org/0.29/#example-42)
-
-This markdown:
-
-
-```markdown
-# foo ##################################
-##### foo ##
-
-```
-
-Gives this correct output:
-
-
-```html
-<h1>foo</h1>
-<h5>foo</h5>
-
-```
-
-### [Example 44](https://spec.commonmark.org/0.29/#example-44)
-
-This markdown:
-
-
-```markdown
-### foo ### b
-
-```
-
-Gives this correct output:
-
-
-```html
-<h3>foo ### b</h3>
-
-```
-
-### [Example 47](https://spec.commonmark.org/0.29/#example-47)
-
-This markdown:
-
-
-```markdown
-****
-## foo
-****
-
-```
-
-Gives this correct output:
-
-
-```html
-<hr />
-<h2>foo</h2>
-<hr />
-
-```
-
-### [Example 48](https://spec.commonmark.org/0.29/#example-48)
-
-This markdown:
-
-
-```markdown
-Foo bar
-# baz
-Bar foo
-
-```
-
-Gives this correct output:
-
-
-```html
-<p>Foo bar</p>
-<h1>baz</h1>
-<p>Bar foo</p>
-
-```
-
-### [Example 49](https://spec.commonmark.org/0.29/#example-49)
-
-This markdown:
-
-
-```markdown
-## 
-#
-### ###
-
-```
-
-Gives this correct output:
-
-
-```html
-<h2></h2>
-<h1></h1>
-<h3></h3>
-
 ```
 

--- a/test/specs/run-spec.js
+++ b/test/specs/run-spec.js
@@ -20,7 +20,7 @@ function runSpecs(title, dir, showCompletionTable, options) {
       writePassingMarkdown(title);
     });
 
-    Object.keys(specs).forEach(section => {
+    Object.keys(specs).sort().forEach(section => {
       describe(section, () => {
         specs[section].specs.forEach(spec => {
           spec.options = Object.assign({}, options, spec.options || {});
@@ -96,8 +96,8 @@ function printStatus() {
     return accumulator;
   },
   {});
-  Object.keys(passedJson).forEach(suiteTitle => {
-    Object.keys(passedJson[suiteTitle]).forEach(section => {
+  Object.keys(passedJson).sort().forEach(suiteTitle => {
+    Object.keys(passedJson[suiteTitle]).sort().forEach(section => {
       passedJson[suiteTitle][section].sort();
     });
   });
@@ -122,7 +122,7 @@ function writeFailuresMarkdown(/** @type {string} */ suiteTitle) {
   {});
 
   /** @type {Object} */ let markdownSections = {};
-  Object.keys(failedJson).forEach(section => {
+  Object.keys(failedJson).sort().forEach(section => {
     /** @type {string} */ let sectionMarkdown = `# ${suiteTitle} - ${section}\n\n`;
     failedJson[section].sort((
       /** @type {Spec} */ specA,
@@ -194,7 +194,7 @@ function writePassingMarkdown(/** @type {string} */ suiteTitle) {
 
   /** @type {string} */ let markdown = "";
   markdown += `# ${suiteTitle}\n\n`;
-  Object.keys(passedJson).forEach(section => {
+  Object.keys(passedJson).sort().forEach(section => {
     markdown += `## ${section}\n\n`;
     passedJson[section].sort((
       /** @type {Spec} */ specA,
@@ -203,7 +203,8 @@ function writePassingMarkdown(/** @type {string} */ suiteTitle) {
       if (specA.example && specB.example) {
         return specA.example - specB.example;
       } else {
-        return 0;
+        // return 0;
+        throw `${section} couldn't sort. \nA: ${specA}\n B: ${specB}`;
       }
     });
     passedJson[section].forEach((/** @type {Spec} */ spec) => {


### PR DESCRIPTION
This avoids noise in the test results files. If there is a diff now, it is only because results have actually changed, not because of random ordering.