### PR TITLE
Rename internal List.Extra module to List.Helpers

### DIFF
--- a/src/List/Helpers.elm
+++ b/src/List/Helpers.elm
@@ -1,4 +1,4 @@
-module List.Extra exposing
+module List.Helpers exposing
     ( last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
     , intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, uniquePairs
     , foldl1, foldr1, indexedFoldl, indexedFoldr

--- a/src/Markdown/Html.elm
+++ b/src/Markdown/Html.elm
@@ -23,7 +23,7 @@ module Markdown.Html exposing
 -}
 
 import Html
-import List.Extra
+import List.Helpers
 import Markdown.Block exposing (Block)
 import Markdown.HtmlRenderer
 
@@ -224,7 +224,7 @@ withAttribute attributeName (Markdown.HtmlRenderer.HtmlRenderer renderer) =
         renderer tagName attributes innerBlocks
             |> (case
                     attributes
-                        |> List.Extra.find
+                        |> List.Helpers.find
                             (\{ name, value } ->
                                 name == attributeName
                             )
@@ -263,7 +263,7 @@ withOptionalAttribute attributeName (Markdown.HtmlRenderer.HtmlRenderer renderer
         renderer tagName attributes innerBlocks
             |> (case
                     attributes
-                        |> List.Extra.find
+                        |> List.Helpers.find
                             (\{ name, value } ->
                                 name == attributeName
                             )


### PR DESCRIPTION
With this change it is possible to vendor `elm-markdown` into an application for development and experimentation, even if that application depends on `elm-community/list-extra`.

Just for the record: Elm-markdown vendors the `List.Extra` module from `elm-community/list-extra` so that it doesn't impose a dependency constraint on `list-extra` for users of `elm-markdown`.