### PR TITLE
Speed improvements

### DIFF
--- a/src/Markdown/InlineParser.elm
+++ b/src/Markdown/InlineParser.elm
@@ -56,9 +56,10 @@ filterTokens filter model =
 
 reverseTokens : Parser -> Parser
 reverseTokens model =
-    { model
-        | tokens =
-            List.reverse model.tokens
+    { rawText = model.rawText
+    , tokens = List.reverse model.tokens
+    , matches = model.matches
+    , refs = model.refs
     }
 
 
@@ -916,7 +917,15 @@ tokensToMatches =
 
 applyTTM : (( List Token, Parser ) -> Parser) -> Parser -> Parser
 applyTTM finderFunction model =
-    finderFunction ( model.tokens, { model | tokens = [] } )
+    let
+        newModel =
+            { rawText = model.rawText
+            , tokens = []
+            , matches = model.matches
+            , refs = model.refs
+            }
+    in
+    finderFunction ( model.tokens, newModel )
 
 
 

--- a/src/ThematicBreak.elm
+++ b/src/ThematicBreak.elm
@@ -91,7 +91,7 @@ statementsHelp state =
                             |> succeed
 
                     _ ->
-                        problem (Parser.Expecting (Debug.toString state))
+                        problem (Parser.Expecting (stateToString state))
             )
 
 
@@ -101,3 +101,19 @@ succeedIfEnough occurences =
 
     else
         problem (Parser.Expecting "...?")
+
+
+stateToString : State -> String
+stateToString state =
+    case state of
+        Asterisk v ->
+            "Asterisk " ++ String.fromInt v
+
+        Hyphen v ->
+            "Hyphen " ++ String.fromInt v
+
+        Underscore v ->
+            "Underscore " ++ String.fromInt v
+
+        NoMatchYet ->
+            "NoMatchYet"


### PR DESCRIPTION
Some improvements that should speed up parsing. 

I found that it's very hard to find out where time is actually spent, so I started with applying equational reasoning to bring down the number of parser api calls. The devtools indicate most time is spent in `map2`, `oneOf` and `andThen`. 

You may know the equation `List.map f |> List.map g = List.map (f >> g)`, where the former goes over the list twice and builds an intermediate list, while the latter only goes over the list once, and does not produce intermediate data.

There are more such equations. The ones I used here are `andThen (\x -> succeed y) = map (\x -> y)` and `List.map f |> combine = traverse f` 

Record update syntax can be slow in loops, so I replaced them with record literals when it showed up in the Devtools profile.

I replaced a use of `Debug`, because with it the benchmarks would not build with `--optimize`. Benchmarks without `--optimize` can be extremely misleading.

Unfortunately, I don't yet see a significant improvement in parsing speed. But the devtools information is becoming more useful because fewer functions are called. For instance I now see that significant time is spent in regexes, while that didn't show up before.

But, I think there are plenty more of these small changes to be made, and that will add up and hopefully expose further optimizations.

But before I start to make a whole bunch of small changes, I'd like some feedback. Also I'd be happy to do a stream on this if you think that'd be fun.