### PR TITLE
Further improve parser

### DIFF
--- a/src/Markdown/OrderedList.elm
+++ b/src/Markdown/OrderedList.elm
@@ -109,13 +109,10 @@ itemBody =
 statementsHelp : String -> ListItem -> List ListItem -> Parser (Step (List ListItem) (List ListItem))
 statementsHelp listMarker firstItem revStmts =
     oneOf
-        [ succeed
-            (\offsetBefore stmt offsetAfter ->
-                Loop (stmt :: revStmts)
-            )
-            |= Advanced.getOffset
-            |= singleItemParser listMarker
-            |= Advanced.getOffset
-        , succeed ()
-            |> map (\_ -> Done (firstItem :: List.reverse revStmts))
+        [ singleItemParser listMarker
+            |> map
+                (\stmt ->
+                    Loop (stmt :: revStmts)
+                )
+        , succeed (Done (firstItem :: List.reverse revStmts))
         ]

--- a/src/Markdown/Parser.elm
+++ b/src/Markdown/Parser.elm
@@ -722,15 +722,14 @@ autolinks are still parsed as paragraphs.
 parseAsParagraphInsteadOfHtmlBlock : Parser RawBlock
 parseAsParagraphInsteadOfHtmlBlock =
     -- ^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>
-    Advanced.succeed ()
-        |. token (Advanced.Token "<" (Parser.Expecting "<"))
+    token (Advanced.Token "<" (Parser.Expecting "<"))
         |. thisIsDefinitelyNotAnHtmlTag
         |. endOfLineOrFile
-        |> getChompedString
-        |> map (\rawLine -> rawLine |> UnparsedInlines |> Body)
+        |> Advanced.mapChompedString (\rawLine _ -> rawLine |> UnparsedInlines |> Body)
         |> Advanced.backtrackable
 
 
+endOfLineOrFile : Parser ()
 endOfLineOrFile =
     Advanced.chompUntilEndOr "\n"
         |. oneOf

--- a/src/Markdown/Parser.elm
+++ b/src/Markdown/Parser.elm
@@ -753,40 +753,22 @@ thisIsDefinitelyNotAnHtmlTag =
         ]
 
 
+joinStringsPreserveAll : String -> String -> String
 joinStringsPreserveAll string1 string2 =
-    String.concat
-        [ string1
-        , "\n"
-        , string2
-        ]
+    string1 ++ "\n" ++ string2
 
 
+joinRawStringsWith : String -> String -> String -> String
 joinRawStringsWith joinWith string1 string2 =
     case ( string1, string2 ) of
-        ( "", "" ) ->
-            String.concat
-                [ string1
-                , string2
-                ]
-
         ( "", _ ) ->
-            String.concat
-                [ string1
-                , string2
-                ]
+            string2
 
         ( _, "" ) ->
-            String.concat
-                [ string1
-                , string2
-                ]
+            string1
 
         _ ->
-            String.concat
-                [ string1
-                , joinWith
-                , string2
-                ]
+            string1 ++ joinWith ++ string2
 
 
 indentedCodeBlock : Parser RawBlock

--- a/src/Markdown/Parser.elm
+++ b/src/Markdown/Parser.elm
@@ -170,43 +170,43 @@ mapInline inline =
                     Block.Strong (inlines |> List.map mapInline)
 
 
-levelParser : Int -> Parser Block.HeadingLevel
-levelParser level =
+toHeading : Int -> Result Parser.Problem Block.HeadingLevel
+toHeading level =
     case level of
         1 ->
-            succeed Block.H1
+            Ok Block.H1
 
         2 ->
-            succeed Block.H2
+            Ok Block.H2
 
         3 ->
-            succeed Block.H3
+            Ok Block.H3
 
         4 ->
-            succeed Block.H4
+            Ok Block.H4
 
         5 ->
-            succeed Block.H5
+            Ok Block.H5
 
         6 ->
-            succeed Block.H6
+            Ok Block.H6
 
         _ ->
-            problem ("A heading with 1 to 6 #'s, but found " ++ String.fromInt level |> Parser.Expecting)
+            Err ("A heading with 1 to 6 #'s, but found " ++ String.fromInt level |> Parser.Expecting)
 
 
 parseInlines : LinkReferenceDefinitions -> RawBlock -> Parser (Maybe Block)
 parseInlines linkReferences rawBlock =
     case rawBlock of
         Heading level unparsedInlines ->
-            level
-                |> levelParser
-                |> map
-                    (\parsedLevel ->
-                        unparsedInlines
-                            |> inlineParseHelper linkReferences
-                            |> (\styledLine -> Just (Block.Heading parsedLevel styledLine))
-                    )
+            case toHeading level of
+                Ok parsedLevel ->
+                    unparsedInlines
+                        |> inlineParseHelper linkReferences
+                        |> (\styledLine -> just (Block.Heading parsedLevel styledLine))
+
+                Err e ->
+                    Advanced.problem e
 
         Body unparsedInlines ->
             unparsedInlines

--- a/src/Parser/Extra.elm
+++ b/src/Parser/Extra.elm
@@ -17,10 +17,8 @@ zeroOrMore condition =
 
 positiveInteger : Parser c Parser.Problem Int
 positiveInteger =
-    succeed ()
-        |. oneOrMore Char.isDigit
-        |> mapChompedString
-            (\str _ -> String.toInt str |> Maybe.withDefault 0)
+    mapChompedString (\str _ -> String.toInt str |> Maybe.withDefault 0) <|
+        oneOrMore Char.isDigit
 
 
 tokenHelp : String -> Parser c Parser.Problem ()

--- a/src/ThematicBreak.elm
+++ b/src/ThematicBreak.elm
@@ -39,6 +39,9 @@ type ThematicToken
 
 statementsHelp : State -> Parser (Advanced.Step State ThematicBreak)
 statementsHelp state =
+    -- Investigate: would splitting this out help?
+    -- e.g. oneOf [ whenThematic, whenFinished, whenWhitespace ]
+    -- makes the case shorter, and allows `map` instead of `andThen` in some branches
     oneOf
         [ tokenHelp "-" |> map (\_ -> Dash)
         , tokenHelp "*" |> map (\_ -> Star)

--- a/test-results/failing/CommonMark/HTML blocks.md
+++ b/test-results/failing/CommonMark/HTML blocks.md
@@ -498,7 +498,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 8 Problem at row 2 Expecting symbol
+ERROR Problem at row 1 Problem at row 2 Expecting symbol
 ````````````
 ## [Example 144](https://spec.commonmark.org/0.29/#example-144)
 

--- a/test-results/failing/GFM/HTML blocks.md
+++ b/test-results/failing/GFM/HTML blocks.md
@@ -498,7 +498,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 8 Problem at row 2 Expecting symbol
+ERROR Problem at row 1 Problem at row 2 Expecting symbol
 ````````````
 ## [Example 144](https://spec.commonmark.org/0.29/#example-144)
 


### PR DESCRIPTION
So, one thing lead to another, and now this is actually quite a big change. I've tried to break it up into very small commits.

I realized that some parts of the parser don't need to be `Parser`, `Result` is fine. Result is much more convenient to work with and to optimize. For instance we can write normal tail-recursive functions, and pattern match on Result.

Two of the end-to-end tests now give a slightly different output. See the commit message for "Test failure is fine". I think the new output is fine, but perhaps I'm missing something.

I also added some notes for future investigation.

