### PR TITLE
Fixed outdated module names in Markdown.Parser example

### DIFF
--- a/src/Markdown/Parser.elm
+++ b/src/Markdown/Parser.elm
@@ -32,13 +32,13 @@ Often you'll want to render these `Block`s directly:
 
     render renderer markdown =
         markdown
-            |> Markdown.parse
+            |> Markdown.Parser.parse
             |> Result.mapError deadEndsToString
-            |> Result.andThen (\ast -> Markdown.render renderer ast)
+            |> Result.andThen (\ast -> Markdown.Renderer.render renderer ast)
 
     deadEndsToString deadEnds =
         deadEnds
-            |> List.map deadEndToString
+            |> List.map Markdown.Parser.deadEndToString
             |> String.join "\n"
 
 But you can also do a lot with the `Block`s before passing them through:


### PR DESCRIPTION
The example didn't compile.

Also, note that the links below the example link to "TODO" and should be fixed too. If you often put "TODO"s in your documentation, it might be worth having an `elm-review` rule for that ;)