### PR TITLE
Inline parser

### DIFF
--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -159,7 +159,7 @@ thematicBreak =
 orderedList =
     Benchmark.benchmark "thematic break"
         (\_ ->
-            Advanced.run (Markdown.OrderedList.parser Nothing)
+            Advanced.run (Markdown.OrderedList.parser False)
                 """1. foo bar
             2. stuff stuff
             3. milk, eggs

--- a/elm.json
+++ b/elm.json
@@ -20,6 +20,8 @@
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
+        "elm-explorations/benchmark": "1.0.1 <= v < 2.0.0",
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0",
+        "elm-explorations/markdown": "1.0.0 <= v < 2.0.0"
     }
 }

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -108,5 +108,10 @@ endOfLineOrFile : Parser ()
 endOfLineOrFile =
     oneOf
         [ Advanced.symbol Token.newline
-        , Advanced.end (Parser.Expecting "end of input")
+        , endOfFile
         ]
+
+
+endOfFile : Parser ()
+endOfFile =
+    Advanced.end (Parser.Expecting "end of input")

--- a/src/Markdown/Entity.elm
+++ b/src/Markdown/Entity.elm
@@ -25,12 +25,17 @@ decimalRegex =
 
 replaceDecimal : Regex.Match -> String
 replaceDecimal match =
-    match.submatches
-        |> List.head
-        |> Maybe.withDefault Nothing
-        |> Maybe.andThen String.toInt
-        |> Maybe.map validUnicode
-        |> Maybe.withDefault match.match
+    case match.submatches of
+        (Just first) :: _ ->
+            case String.toInt first of
+                Just v ->
+                    validUnicode v
+
+                Nothing ->
+                    match.match
+
+        _ ->
+            match.match
 
 
 validUnicode : Int -> String
@@ -103,22 +108,23 @@ hexadecimalRegex =
 
 replaceHexadecimal : Regex.Match -> String
 replaceHexadecimal match =
-    match.submatches
-        |> List.head
-        |> Maybe.withDefault Nothing
-        |> Maybe.map (hexToInt >> validUnicode)
-        |> Maybe.withDefault match.match
+    case match.submatches of
+        (Just first) :: _ ->
+            validUnicode (hexToInt first)
+
+        _ ->
+            match.match
 
 
 hexToInt : String -> Int
-hexToInt =
-    String.toLower
-        >> String.toList
-        >> List.foldl
-            (\hexDigit int ->
-                int * 16 + modBy 39 (Char.toCode hexDigit) - 9
-            )
-            0
+hexToInt string =
+    let
+        folder hexDigit int =
+            int * 16 + modBy 39 (Char.toCode hexDigit) - 9
+    in
+    string
+        |> String.toLower
+        |> String.foldl folder 0
 
 
 
@@ -140,12 +146,17 @@ entitiesRegex =
 
 replaceEntity : Regex.Match -> String
 replaceEntity match =
-    match.submatches
-        |> List.head
-        |> Maybe.withDefault Nothing
-        |> Maybe.andThen (\a -> Dict.get a entities)
-        |> Maybe.map (Char.fromCode >> String.fromChar)
-        |> Maybe.withDefault match.match
+    case match.submatches of
+        (Just first) :: _ ->
+            case Dict.get first entities of
+                Just code ->
+                    String.fromChar (Char.fromCode code)
+
+                Nothing ->
+                    match.match
+
+        _ ->
+            match.match
 
 
 

--- a/src/Markdown/Helpers.elm
+++ b/src/Markdown/Helpers.elm
@@ -44,8 +44,7 @@ whiteSpaceChars =
 
 prepareRefLabel : String -> String
 prepareRefLabel =
-    cleanWhitespaces
-        >> String.toLower
+    cleanWhitespaces >> String.toLower
 
 
 cleanWhitespaces : String -> String

--- a/src/Markdown/InlineParser.elm
+++ b/src/Markdown/InlineParser.elm
@@ -32,25 +32,28 @@ initParser refs rawText =
 
 addMatch : Parser -> Match -> Parser
 addMatch model match =
-    { model
-        | matches =
-            match :: model.matches
+    { rawText = model.rawText
+    , tokens = model.tokens 
+    , matches = match :: model.matches
+    , refs = model.refs
     }
 
 
 addToken : Parser -> Token -> Parser
 addToken model token =
-    { model
-        | tokens =
-            token :: model.tokens
+    { rawText = model.rawText
+    , tokens = token :: model.tokens
+    , matches = model.matches
+    , refs = model.refs
     }
 
 
 filterTokens : (Token -> Bool) -> Parser -> Parser
 filterTokens filter model =
-    { model
-        | tokens =
-            List.filter filter model.tokens
+    { rawText = model.rawText
+    , tokens = List.filter filter model.tokens
+    , matches = model.matches
+    , refs = model.refs
     }
 
 
@@ -1944,7 +1947,7 @@ lineBreakTTM tokens model =
                     }
 
             else
-                lineBreakTTM tokensTail ( addToken model token)
+                lineBreakTTM tokensTail (addToken model token)
 
 
 

--- a/src/Markdown/OrderedList.elm
+++ b/src/Markdown/OrderedList.elm
@@ -16,18 +16,17 @@ type alias ListItem =
     String
 
 
-parser : Maybe RawBlock -> Parser ( Int, List ListItem )
-parser lastBlock =
+parser : Bool -> Parser ( Int, List ListItem )
+parser previousWasBody =
     succeed parseSubsequentItems
         -- NOTE this is only a list item when there is at least one space after the marker
         -- so the first parts must be backtrackable.
         |= backtrackable
-            (case lastBlock of
-                Just (Body _) ->
-                    positiveIntegerMaxOf9Digits |> andThen validateStartsWith1
+            (if previousWasBody then
+                positiveIntegerMaxOf9Digits |> andThen validateStartsWith1
 
-                _ ->
-                    positiveIntegerMaxOf9Digits
+             else
+                positiveIntegerMaxOf9Digits
             )
         |= backtrackable
             (Advanced.oneOf

--- a/src/Markdown/OrderedList.elm
+++ b/src/Markdown/OrderedList.elm
@@ -44,7 +44,7 @@ parser previousWasBody =
 
 parseSubsequentItems : Int -> Token Parser.Problem -> ListItem -> Parser ( Int, List ListItem )
 parseSubsequentItems startingIndex listMarker firstItem =
-    loop [] (statementsHelp listMarker)
+    loop [] (statementsHelp (singleItemParser listMarker))
         |> map (\items -> ( startingIndex, firstItem :: items ))
 
 
@@ -103,10 +103,10 @@ endOrNewline =
         ]
 
 
-statementsHelp : Token Parser.Problem -> List ListItem -> Parser (Step (List ListItem) (List ListItem))
-statementsHelp listMarker revStmts =
+statementsHelp : Parser ListItem -> List ListItem -> Parser (Step (List ListItem) (List ListItem))
+statementsHelp itemParser revStmts =
     oneOf
-        [ succeed (\stmt -> Loop (stmt :: revStmts))
-            |= singleItemParser listMarker
+        [ itemParser
+            |> Advanced.map (\stmt -> Loop (stmt :: revStmts))
         , succeed (Done (List.reverse revStmts))
         ]

--- a/src/Markdown/Parser.elm
+++ b/src/Markdown/Parser.elm
@@ -340,8 +340,7 @@ plainLine =
 
 innerParagraphParser : Parser RawBlock
 innerParagraphParser =
-    Advanced.chompIf (\c -> not <| Helpers.isNewline c) (Parser.Expecting "Not newline.")
-        |. Advanced.chompUntilEndOr "\n"
+    Advanced.chompUntilEndOr "\n"
         |> Advanced.mapChompedString
             (\rawLine _ ->
                 rawLine

--- a/src/Markdown/UnorderedList.elm
+++ b/src/Markdown/UnorderedList.elm
@@ -16,7 +16,7 @@ parser : Parser (List ListItem)
 parser =
     let
         parseSubsequentItems listMarker firstItem =
-            loop [] (statementsHelp listMarker firstItem)
+            loop [] (statementsHelp (singleItemParser listMarker) firstItem)
     in
     succeed parseSubsequentItems
         |= backtrackable listMarkerParser
@@ -55,10 +55,10 @@ itemBody =
         ]
 
 
-statementsHelp : Token Parser.Problem -> ListItem -> List ListItem -> Parser (Step (List ListItem) (List ListItem))
-statementsHelp listMarker firstItem revStmts =
+statementsHelp : Parser ListItem -> ListItem -> List ListItem -> Parser (Step (List ListItem) (List ListItem))
+statementsHelp itemParser firstItem revStmts =
     oneOf
-        [ succeed (\stmt -> Loop (stmt :: revStmts))
-            |= singleItemParser listMarker
+        [ itemParser
+            |> Advanced.map (\stmt -> Loop (stmt :: revStmts))
         , succeed (Done (firstItem :: List.reverse revStmts))
         ]

--- a/tests/OrderedListTests.elm
+++ b/tests/OrderedListTests.elm
@@ -21,7 +21,7 @@ suite =
 2. Item 2
 3. Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -36,7 +36,7 @@ suite =
                 """1. Item 1
 2. Item 2
 3. Item 3"""
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -52,7 +52,7 @@ suite =
 1. Item 2
 1. Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -68,7 +68,7 @@ suite =
 3. Item 2
 8. Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -84,7 +84,7 @@ suite =
 3. Item 2
 3. Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 3
@@ -100,7 +100,7 @@ suite =
 1. Item 2
 2. Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 0
@@ -116,7 +116,7 @@ suite =
 0003. Item 2
 00003. Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 3
@@ -132,7 +132,7 @@ suite =
 2. Item 2
 1. Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 3
@@ -148,7 +148,7 @@ suite =
 2) Item 2
 3) Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -164,7 +164,7 @@ suite =
 3) Item 2
 3) Item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 3
@@ -183,7 +183,7 @@ suite =
 2. Item 5
 3. Item 6
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -199,7 +199,7 @@ suite =
 2. bar
 3) baz
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -214,7 +214,7 @@ suite =
 2.
 3. bar
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.equal
                         (Ok
                             ( 1
@@ -228,25 +228,25 @@ suite =
             \() ->
                 """4.3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.err
         , test "A list that doesn't have a space after the period marker" <|
             \() ->
                 """1.testing
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.err
         , test "A list that doesn't have a space after the parenthesis marker" <|
             \() ->
                 """1)testing
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.err
         , test "Text starting with a parenthetical statement" <|
             \() ->
                 """(test) data
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.err
         , test "A list cannot start with a number longer than 9 digits" <|
             \() ->
@@ -254,6 +254,6 @@ suite =
 1234567891. item 2
 1234567892. item 3
 """
-                    |> Advanced.run (Markdown.OrderedList.parser Nothing)
+                    |> Advanced.run (Markdown.OrderedList.parser False)
                     |> Expect.err
         ]


### PR DESCRIPTION
On my machine I get a 22% speed increase for the largest benchmark. (it gets some 3400 runs per second now, which was ~2700 during the stream).

There is a bunch of neat lessons in here 

* regex on small strings is slow. Better to use `String.foldl` if you can
* many record updates were eliminated
* a `case` on a custom type is faster than `== Constructor`, which can matter.
* remove allocation/wrapping when possible

I also added some of the micro benchmarks to the benchmarks file. Working with `elm-bench` has been really great.