### PR TITLE
Faster html parser

### DIFF
--- a/src/HtmlParser.elm
+++ b/src/HtmlParser.elm
@@ -85,7 +85,14 @@ docType =
 
 allUppercase : Parser String
 allUppercase =
-    keepOneOrMore Char.isUpper
+    Advanced.chompIf Char.isUpper expectUppercaseCharacter
+        |. chompWhile Char.isUpper
+        |> getChompedString
+
+
+expectUppercaseCharacter : Parser.Problem
+expectUppercaseCharacter =
+    Parser.Expecting "at least 1 uppercase character"
 
 
 html : Parser Node
@@ -123,9 +130,14 @@ elementContinuation startTagName =
 
 tagName : Parser String
 tagName =
-    Advanced.chompIf tagNameCharacter (Parser.Expecting "at least one")
+    Advanced.chompIf tagNameCharacter expectTagNameCharacter
         |. chompWhile tagNameCharacter
         |> Advanced.mapChompedString (\name _ -> String.toLower name)
+
+
+expectTagNameCharacter : Parser.Problem
+expectTagNameCharacter =
+    Parser.Expecting "at least 1 tag name character"
 
 
 tagNameCharacter : Char -> Bool
@@ -510,13 +522,6 @@ escape s =
 
 
 -- UTILITY
-
-
-keepOneOrMore : (Char -> Bool) -> Parser String
-keepOneOrMore predicate =
-    Advanced.chompIf predicate (Parser.Expecting "at least one")
-        |. chompWhile predicate
-        |> getChompedString
 
 
 fail : String -> Parser a

--- a/src/HtmlParser.elm
+++ b/src/HtmlParser.elm
@@ -241,18 +241,21 @@ textString closingChar =
         predicate c =
             c /= closingChar && c /= '&'
     in
-    Advanced.loop () (textStringStep closingChar predicate)
+    Advanced.loop "" (textStringStep closingChar predicate)
+
+
+textStringStep : Char -> (Char -> Bool) -> String -> Parser (Step String String)
+textStringStep closingChar predicate accum =
+    chompWhile predicate
         |> getChompedString
-
-
-textStringStep closingChar predicate _ =
-    succeed identity
-        |. chompWhile predicate
-        |= oneOf
-            [ escapedChar closingChar
-                |> map (\_ -> Loop ())
-            , succeed (Done ())
-            ]
+        |> andThen
+            (\soFar ->
+                oneOf
+                    [ escapedChar closingChar
+                        |> map (\escaped -> Loop (accum ++ soFar ++ String.fromChar escaped))
+                    , succeed (Done (accum ++ soFar))
+                    ]
+            )
 
 
 

--- a/src/Markdown/Parser.elm
+++ b/src/Markdown/Parser.elm
@@ -655,11 +655,11 @@ stepRawBlock revStmts =
     case revStmts.rawBlocks of
         (Body _) :: _ ->
             oneOf whenPreviousWasBody
-                |= succeed revStmts
+                |> map (\f -> f revStmts)
 
         _ ->
             oneOf whenPreviousWasNotBody
-                |= succeed revStmts
+                |> map (\f -> f revStmts)
 
 
 

--- a/test-results/failing/CommonMark/HTML blocks.md
+++ b/test-results/failing/CommonMark/HTML blocks.md
@@ -95,7 +95,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 125](https://spec.commonmark.org/0.29/#example-125)
 
@@ -333,7 +333,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 136](https://spec.commonmark.org/0.29/#example-136)
 

--- a/test-results/failing/CommonMark/HTML blocks.md
+++ b/test-results/failing/CommonMark/HTML blocks.md
@@ -95,7 +95,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 125](https://spec.commonmark.org/0.29/#example-125)
 
@@ -333,7 +333,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 136](https://spec.commonmark.org/0.29/#example-136)
 

--- a/test-results/failing/CommonMark/Raw HTML.md
+++ b/test-results/failing/CommonMark/Raw HTML.md
@@ -223,7 +223,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 620](https://spec.commonmark.org/0.29/#example-620)
 
@@ -243,7 +243,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 622](https://spec.commonmark.org/0.29/#example-622)
 

--- a/test-results/failing/CommonMark/Raw HTML.md
+++ b/test-results/failing/CommonMark/Raw HTML.md
@@ -223,7 +223,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 620](https://spec.commonmark.org/0.29/#example-620)
 
@@ -243,7 +243,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 622](https://spec.commonmark.org/0.29/#example-622)
 

--- a/test-results/failing/GFM/HTML blocks.md
+++ b/test-results/failing/GFM/HTML blocks.md
@@ -95,7 +95,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 125](https://spec.commonmark.org/0.29/#example-125)
 
@@ -333,7 +333,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 136](https://spec.commonmark.org/0.29/#example-136)
 

--- a/test-results/failing/GFM/HTML blocks.md
+++ b/test-results/failing/GFM/HTML blocks.md
@@ -95,7 +95,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 125](https://spec.commonmark.org/0.29/#example-125)
 
@@ -333,7 +333,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 136](https://spec.commonmark.org/0.29/#example-136)
 

--- a/test-results/failing/GFM/Raw HTML.md
+++ b/test-results/failing/GFM/Raw HTML.md
@@ -223,7 +223,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 620](https://spec.commonmark.org/0.29/#example-620)
 
@@ -243,7 +243,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````
 ## [Example 622](https://spec.commonmark.org/0.29/#example-622)
 

--- a/test-results/failing/GFM/Raw HTML.md
+++ b/test-results/failing/GFM/Raw HTML.md
@@ -223,7 +223,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 620](https://spec.commonmark.org/0.29/#example-620)
 
@@ -243,7 +243,7 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````
 ## [Example 622](https://spec.commonmark.org/0.29/#example-622)
 

--- a/test-results/failing/New/mangle_xss.md
+++ b/test-results/failing/New/mangle_xss.md
@@ -20,5 +20,5 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Expecting at least one
+ERROR Problem at row 1 Expecting at least 1 tag name character
 ````````````

--- a/test-results/failing/New/mangle_xss.md
+++ b/test-results/failing/New/mangle_xss.md
@@ -20,5 +20,5 @@ Should give output:
 But instead was:
 
 ````````````html
-ERROR Problem at row 1 Bad repeat
+ERROR Problem at row 1 Expecting at least one
 ````````````

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -477,8 +477,9 @@ I'm part of the block quote
                                     [ Block.Text "italicized inline HTML "
                                     , Block.HtmlInline
                                         (Block.HtmlElement "bio"
-                                            [ { name = "name", value = "Dillon Kearns" }
-                                            , { name = "photo", value = "https://avatars2.githubusercontent.com/u/1384166" }
+                                            -- NOTE: attribute names are in reverse alphabetical order
+                                            [ { name = "photo", value = "https://avatars2.githubusercontent.com/u/1384166" }
+                                            , { name = "name", value = "Dillon Kearns" }
                                             ]
                                             []
                                         )


### PR DESCRIPTION
The html parser used explicit recursion, which is both slower and can't be tail-call optimized.

I get ~4300 runs per second with this. I think that's about the best we can do with the current `elm/parser` and approach.