### PR TITLE
Run inline parser within Inline HTML

### DIFF
--- a/src/Markdown/Block.elm
+++ b/src/Markdown/Block.elm
@@ -303,22 +303,6 @@ extractInlineBlockText block =
             ""
 
 
-
---BlockQuote blocks ->
---
---
---Heading headingLevel inlines ->
---
---
---Table list lists ->
---
---
---CodeBlock record ->
---
---
---ThematicBreak ->
-
-
 {-| The way HTML is handled is one of the core ideas of this library.
 
 You get the full HTML structure that you can use to process the Blocks before rendering them. Once you render them,

--- a/src/Markdown/HtmlRenderer.elm
+++ b/src/Markdown/HtmlRenderer.elm
@@ -1,11 +1,16 @@
-module Markdown.HtmlRenderer exposing (Attribute, HtmlRenderer(..))
+module Markdown.HtmlRenderer exposing (Attribute, HtmlRenderer(..), InlineOrBlock(..))
 
-import Markdown.Block exposing (Block)
+import Markdown.Block exposing (Block, Inline)
 
 
 type alias Attribute =
     { name : String, value : String }
 
 
+type InlineOrBlock
+    = Inline Inline
+    | Block Block
+
+
 type HtmlRenderer a
-    = HtmlRenderer (String -> List Attribute -> List Block -> Result String a)
+    = HtmlRenderer (String -> List Attribute -> List InlineOrBlock -> Result String a)

--- a/src/Markdown/Parser.elm
+++ b/src/Markdown/Parser.elm
@@ -177,7 +177,7 @@ mapInline inline =
 
         Inline.HtmlInline node ->
             node
-                |> nodeToRawBlock
+                |> nodeToRawInline
                 |> Block.HtmlInline
 
         Inline.Emphasis level inlines ->
@@ -536,6 +536,11 @@ textNodeToBlocks textNodeValue =
         |> Result.withDefault []
 
 
+textNodeToInlines : String -> List Inline
+textNodeToInlines textNodeValue =
+    inlineParseHelper [] (UnparsedInlines textNodeValue)
+
+
 nodeToRawBlock : Node -> Block.Html Block
 nodeToRawBlock node =
     case node of
@@ -551,6 +556,39 @@ nodeToRawBlock node =
 
                         _ ->
                             [ nodeToRawBlock child |> Block.HtmlBlock ]
+            in
+            Block.HtmlElement tag
+                attributes
+                (List.concatMap parseChild children)
+
+        Comment string ->
+            Block.HtmlComment string
+
+        Cdata string ->
+            Block.Cdata string
+
+        ProcessingInstruction string ->
+            Block.ProcessingInstruction string
+
+        Declaration declarationType content ->
+            Block.HtmlDeclaration declarationType content
+
+
+nodeToRawInline : Node -> Block.Html Inline
+nodeToRawInline node =
+    case node of
+        HtmlParser.Text innerText ->
+            Block.HtmlComment "TODO this never happens, but use types to drop this case."
+
+        HtmlParser.Element tag attributes children ->
+            let
+                parseChild child =
+                    case child of
+                        HtmlParser.Text text ->
+                            textNodeToInlines text
+
+                        _ ->
+                            [ nodeToRawInline child |> Block.HtmlInline ]
             in
             Block.HtmlElement tag
                 attributes

--- a/src/Markdown/Renderer.elm
+++ b/src/Markdown/Renderer.elm
@@ -309,7 +309,9 @@ renderHtml tagName attributes children (Markdown.HtmlRenderer.HtmlRenderer htmlR
         |> combineResults
         |> Result.andThen
             (\okChildren ->
-                htmlRenderer tagName attributes children
+                children
+                    |> List.map Markdown.HtmlRenderer.Block
+                    |> htmlRenderer tagName attributes
                     |> Result.map
                         (\myRenderer -> myRenderer okChildren)
             )
@@ -579,7 +581,7 @@ renderSingleInline renderer inline =
         Block.HtmlInline html ->
             case html of
                 Block.HtmlElement tag attributes children ->
-                    renderHtmlNode renderer tag attributes children
+                    renderInlineHtmlNode renderer tag attributes children
                         |> Just
 
                 _ ->
@@ -593,3 +595,39 @@ renderHtmlNode renderer tag attributes children =
         children
         renderer.html
         (renderHelper renderer children)
+
+
+renderInlineHtmlNode : Renderer view -> String -> List Attribute -> List Inline -> Result String view
+renderInlineHtmlNode renderer tag attributes children =
+    renderInlineHtml tag
+        attributes
+        children
+        renderer.html
+        (renderHelperInline renderer children)
+
+
+renderInlineHtml :
+    String
+    -> List Attribute
+    -> List Inline
+    -> Markdown.Html.Renderer (List view -> view)
+    -> Result String (List view)
+    -> Result String view
+renderInlineHtml tagName attributes children (Markdown.HtmlRenderer.HtmlRenderer htmlRenderer) renderedChildren =
+    renderedChildren
+        |> Result.andThen
+            (\okChildren ->
+                children
+                    |> List.map Markdown.HtmlRenderer.Inline
+                    |> htmlRenderer tagName attributes
+                    |> Result.map
+                        (\myRenderer -> myRenderer okChildren)
+            )
+
+
+renderHelperInline :
+    Renderer view
+    -> List Inline
+    -> Result String (List view)
+renderHelperInline renderer blocks =
+    renderStyled renderer blocks


### PR DESCRIPTION
The block parser shouldn't run within an Inline HTML tag. However, I still need to clarify what to do for HTML renderers here. There are a few different approaches that need to be considered. I'll discuss in a separate issue.