### PR TITLE
Add missing fields to defaultRenderer example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ defaultHtmlRenderer =
                 )
     , html = Markdown.Html.oneOf []
     , codeBlock =
-        \{ body, language } ->
+        \block ->
             Html.pre []
                 [ Html.code []
-                    [ Html.text body
+                    [ Html.text block.body
                     ]
                 ]
     , thematicBreak = Html.hr [] []
@@ -207,8 +207,10 @@ defaultHtmlRenderer =
                         |> Maybe.withDefault []
             in
             Html.th attrs
-    , tableCell = Html.td []
+    , tableCell = \_ children -> Html.td [] children
+    , strikethrough = Html.span [ Attr.style "text-decoration-line" "line-through" ]
     }
+
 ```
 
 


### PR DESCRIPTION
The originally provided example does not compile because it's missing the `strikethrough` field and has a wrong signature for `tableCell`