### PR TITLE
Fix inline parser regarding < and > chars in Html

### DIFF
--- a/src/Markdown/InlineParser.elm
+++ b/src/Markdown/InlineParser.elm
@@ -250,8 +250,36 @@ tokenize rawText =
         |> mergeByIndex (findLinkImageOpenTokens rawText)
         |> mergeByIndex (findLinkImageCloseTokens rawText)
         |> mergeByIndex (findHardBreakTokens rawText)
-        |> mergeByIndex (findAngleBracketLTokens rawText)
-        |> mergeByIndex (findAngleBracketRTokens rawText)
+        |> mergeByIndex 
+        (cleanAngleBracketTokens (rawText |> findAngleBracketLTokens |> List.sortBy .index) (rawText |> findAngleBracketRTokens |> List.sortBy .index) 0)
+
+
+cleanAngleBracketTokens : List { a | index : Int } -> List { a | index : Int } -> Int -> List { a | index : Int }
+cleanAngleBracketTokens tokensL tokensR countL=
+    case tokensR of
+        [] -> []
+        hd1 :: rest1 ->
+            case tokensL of
+                [] -> 
+                    if countL > 1 then
+                        cleanAngleBracketTokens tokensL rest1 (countL - 1)
+                    else if countL == 1 then
+                        hd1 :: (cleanAngleBracketTokens tokensL rest1 (countL - 1))
+                    else
+                        cleanAngleBracketTokens tokensL rest1 0
+                hd :: rest ->
+                    if (hd.index < hd1.index) then
+                        if countL == 0 then
+                            hd :: (cleanAngleBracketTokens rest tokensR (countL + 1))
+                        else
+                            cleanAngleBracketTokens rest tokensR (countL + 1)
+                    else
+                        if countL > 1 then
+                            cleanAngleBracketTokens tokensL rest1 (countL - 1)
+                        else if countL == 1 then
+                            hd1 :: (cleanAngleBracketTokens tokensL rest1 (countL - 1))
+                        else
+                            cleanAngleBracketTokens tokensL rest1 0
 
 
 {-| Merges two sorted sequences into a sorted sequence

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -118,6 +118,25 @@ Hello!
                                 )
                             ]
                         )
+        , test "embedded HTML with attribute containing <> chars" <|
+            \() ->
+                """# Heading
+<div attr="<u>">
+Hello!
+</div>
+"""
+                    |> parse
+                    |> Expect.equal
+                        (Ok
+                            [ Block.Heading Block.H1 (unstyledText "Heading")
+                            , Block.HtmlBlock
+                                (Block.HtmlElement "div"
+                                    [ { name = "attr", value = "<u>" } ]
+                                    [ Block.Paragraph (unstyledText "Hello!")
+                                    ]
+                                )
+                            ]
+                        )
         , test "heading within HTML" <|
             \() ->
                 """# Heading
@@ -583,6 +602,28 @@ I'm part of the block quote
                                         (Block.HtmlElement "bio"
                                             -- NOTE: attribute names are in reverse alphabetical order
                                             [ { name = "photo", value = "https://avatars2.githubusercontent.com/u/1384166" }
+                                            , { name = "name", value = "Dillon Kearns" }
+                                            ]
+                                            []
+                                        )
+                                    ]
+                                ]
+                            ]
+                        )
+        , test "inline HTML with an attribute with <> chars" <|
+            \() ->
+                """This is *italicized inline HTML <bio name="Dillon Kearns" photo="https://avatars2.githubusercontent.com/<u>/1384166" />*"""
+                    |> parse
+                    |> Expect.equal
+                        (Ok
+                            [ Block.Paragraph
+                                [ Block.Text "This is "
+                                , Block.Emphasis
+                                    [ Block.Text "italicized inline HTML "
+                                    , Block.HtmlInline
+                                        (Block.HtmlElement "bio"
+                                            -- NOTE: attribute names are in reverse alphabetical order
+                                            [ { name = "photo", value = "https://avatars2.githubusercontent.com/<u>/1384166" }
                                             , { name = "name", value = "Dillon Kearns" }
                                             ]
                                             []


### PR DESCRIPTION
As discussed in https://github.com/dillonkearns/elm-markdown/issues/123