### PR TITLE
Add testcase for link with angle brackets

### DIFF
--- a/spec-tests/specs/original/angular_links.html
+++ b/spec-tests/specs/original/angular_links.html
@@ -1,0 +1,1 @@
+<p><a href="http://example.com/">Link</a>.</p>

--- a/spec-tests/specs/original/angular_links.md
+++ b/spec-tests/specs/original/angular_links.md
@@ -1,0 +1,1 @@
+[Link](<http://example.com/>).


### PR DESCRIPTION
The parser produces wrong output for inputs of the form

```markdown
[Link](<http://example.com/>).
```

This is currently a draft because it's lacking the actual fix :)